### PR TITLE
Only pass original request path, not full URL, to login page redirect

### DIFF
--- a/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
@@ -36,7 +36,7 @@ http {
 
         # Redirect any unauthorised users to the login page
         location @error401 {
-            return 302 https://$host/users/login?redirect=https://$host$request_uri;
+            return 302 https://$host/users/login?redirect=$request_uri;
         }
 
         # Use API endpoint in user-service for checking authentication


### PR DESCRIPTION
As the title says. Previously, the `redirect` URL parameter for the login page accepted a full URL to redirect to once the user has successfully logged in.

Now that the Nginx auth is coming together, everything will be under a single hostname, and so we don't need (or want) to allow a full URL to be specified. Instead, only a path is specified, which is used to redirect somewhere else on the same hostname as everything else.

This PR updates the Nginx config for the auth proxy to only pass the original request path to the login page, rather than the full URL.