### PR TITLE
Allow Nginx auth proxy to optionally be served on non-standard ports

### DIFF
--- a/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
@@ -25,7 +25,7 @@ http {
     server_tokens             off;
 
     server {
-        listen                          443   ssl;
+        listen                          {{ atoi (getv "/cjse/nginx/port/https" "443") }} ssl;
         ssl_certificate                 /certs/server.crt;
         ssl_certificate_key             /certs/server.key;
         ssl_protocols                   TLSv1.2;
@@ -36,7 +36,7 @@ http {
 
         # Redirect any unauthorised users to the login page
         location @error401 {
-            return 302 https://$host/users/login?redirect=$request_uri;
+            return 302 /users/login?redirect=$request_uri;
         }
 
         # Use API endpoint in user-service for checking authentication
@@ -86,7 +86,7 @@ http {
     }
 
     server {
-      listen        80 default_server;
+      listen        {{ atoi (getv "/cjse/nginx/port/http" "80") }} default_server;
       server_name   _;
       return        301 https://$host$request_uri;
       error_log     /dev/stdout info;


### PR DESCRIPTION
In order to make the developer experience nicer, we think that it should be possible to run the Nginx auth proxy on an unprivileged port (i.e. >1024) - as running the container on the standard port 80/443 requires the docker daemon to be running with root privileges.

This change allows port numbers to be specified with the `$CJSE_NGINX_PORT_HTTP` and `$CJSE_NGINX_PORT_HTTPS` environment variables, which default to 80 and 443 if not specified, respectively.