### PR TITLE
Add audit-logging to nginx auth proxy

### DIFF
--- a/Nginx_Auth_Proxy/Makefile
+++ b/Nginx_Auth_Proxy/Makefile
@@ -6,6 +6,7 @@ build:
 	docker build -t "$(image)" .
 	bash -c "GOSS_SLEEP=15 dgoss run \
 			-e CJSE_NGINX_USERSERVICE_DOMAIN="localhost/elb-status" \
+			-e CJSE_NGINX_AUDITLOGGING_DOMAIN="localhost/elb-status" \
 			-e CJSE_NGINX_APP_DOMAIN="localhost/elb-status" \
 			-e CJSE_NGINX_PROXYSSLVERIFY="off" \
 			$(image)"

--- a/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
@@ -66,6 +66,18 @@ http {
             limit_except GET POST PUT DELETE { deny all; }
         }
 
+        # Proxy through to audit-logging
+        location /audit-logging {
+            error_page 401 = @error401;
+            error_page 403 = @error403;
+            auth_request /auth;
+
+            proxy_pass        https://{{ getv "/cjse/nginx/auditlogging/domain" }};
+            proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
+
+            limit_except GET POST PUT DELETE { deny all; }
+        }
+
         # Proxy through to user-service
         location /users {
             error_page 401 = @error401;


### PR DESCRIPTION
This PR adds a new location to Nginx Auth Proxy for Audit logging.