### PR TITLE
Update CSP header for audit logging

### DIFF
--- a/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
@@ -132,6 +132,7 @@ http {
             auth_request /auth;
             auth_request_set $auth_cookie $upstream_http_set_cookie;
             add_header Set-Cookie $auth_cookie;
+            add_header Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';" always;
 
             proxy_pass        https://$auditlogging;
             proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};


### PR DESCRIPTION
Updated content security policy header for audit logging:
- Added `style-src 'self' 'unsafe-inline';` to fix inline styling issue
- Added `img-src 'self' data:;` to fix base64 images issue