### PR TITLE
Fix issue with using add_header directive in location blocks

### DIFF
--- a/Nginx_Auth_Proxy/Dockerfile
+++ b/Nginx_Auth_Proxy/Dockerfile
@@ -2,3 +2,4 @@ ARG BUILD_IMAGE="nginx-supervisord"
 FROM ${BUILD_IMAGE}
 
 COPY confd /etc/confd/
+COPY includes /etc/includes/

--- a/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
@@ -87,7 +87,7 @@ http {
         # Use API endpoint in user-service for checking authentication
         location /auth {
             limit_except      GET POST PUT { deny all; }
-            # include /etc/includes/without-auth-headers.conf;
+            include /etc/includes/without-auth-headers.conf;
 
             proxy_pass        https://$userservice/users/api/auth;
             proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};

--- a/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
@@ -65,7 +65,7 @@ http {
         error_page 401 = @error401;
         location @error401 {
             limit_except      GET POST PUT { deny all; }
-            include /etc/includes/default-headers.conf;
+            include /etc/includes/without-auth-headers.conf;
             proxy_ssl_server_name on;
             proxy_ssl_verify_depth 2;
             return 302 /users/login?redirect=$request_uri;
@@ -78,7 +78,7 @@ http {
         location ~ ^/(403|404|500)$ {
             proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
             limit_except      GET POST PUT { deny all; }
-            include /etc/includes/default-headers.conf;
+            include /etc/includes/without-auth-headers.conf;
             proxy_ssl_server_name on;
             proxy_ssl_verify_depth 2;
             rewrite /(.*) /users/$1;
@@ -87,7 +87,7 @@ http {
         # Use API endpoint in user-service for checking authentication
         location /auth {
             limit_except      GET POST PUT { deny all; }
-            include /etc/includes/default-headers.conf;
+            # include /etc/includes/without-auth-headers.conf;
 
             proxy_pass        https://$userservice/users/api/auth;
             proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
@@ -103,7 +103,7 @@ http {
         # Proxy for landing page to Bichard
         location = / {
             limit_except GET POST PUT DELETE { deny all; }
-            include /etc/includes/default-headers.conf;
+            include /etc/includes/with-auth-headers.conf;
             return 302 /users;
         }
 
@@ -112,7 +112,7 @@ http {
             limit_except GET POST PUT DELETE { deny all; }
             auth_request /auth;
             auth_request_set $auth_cookie $upstream_http_set_cookie;
-            include /etc/includes/default-headers.conf;
+            include /etc/includes/with-auth-headers.conf;
             add_header Set-Cookie $auth_cookie;
 
             proxy_pass        https://$app;
@@ -146,7 +146,7 @@ http {
             limit_except GET POST PUT DELETE { deny all; }
             auth_request /auth;
             auth_request_set $auth_cookie $upstream_http_set_cookie;
-            include /etc/includes/default-headers.conf;
+            include /etc/includes/with-auth-headers.conf;
             add_header Set-Cookie $auth_cookie;
 
             proxy_pass        https://$userservice;
@@ -164,7 +164,7 @@ http {
             limit_except GET { deny all; }
             auth_request /auth;
             auth_request_set $auth_cookie $upstream_http_set_cookie;
-            include /etc/includes/default-headers.conf;
+            include /etc/includes/with-auth-headers.conf;
             add_header Set-Cookie $auth_cookie;
 
             proxy_pass        https://$staticservice;
@@ -178,7 +178,7 @@ http {
         # Proxy through to help files without auth
         location /help {
             limit_except GET { deny all; }
-            include /etc/includes/default-headers.conf;
+            include /etc/includes/without-auth-headers.conf;
 
             proxy_pass        https://$staticservice;
             proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
@@ -191,7 +191,7 @@ http {
         # Allow access to user-service login flow (and necessary assets) without authentication
         location ~ ^/users/(login|assets|_next/static|403|404|500)(.*)$ {
             limit_except GET POST PUT { deny all; }
-            include /etc/includes/default-headers.conf;
+            include /etc/includes/without-auth-headers.conf;
 
             proxy_pass        https://$userservice;
             proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
@@ -202,7 +202,7 @@ http {
 
         # Allow access to bichard-ui health check, connectivity and static endpoints without authentication
         location ~ ^/bichard-ui/(Health|Connectivity|images|css).*$ {
-            include /etc/includes/default-headers.conf;
+            include /etc/includes/without-auth-headers.conf;
             proxy_pass        https://$app;
             proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
             proxy_cookie_flags ~ httponly secure samesite=strict;
@@ -211,7 +211,7 @@ http {
         # Healthcheck endpoint
         location /elb-status {
             limit_except GET POST { deny all; }
-            include /etc/includes/default-headers.conf;
+            include /etc/includes/without-auth-headers.conf;
             access_log   off;
             return       200;
             add_header   Content-Type text/plain;

--- a/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
@@ -47,15 +47,6 @@ http {
         ssl_certificate_key             /certs/server.key;
         ssl_protocols                   TLSv1.2;
         ssl_ciphers                     HIGH:!aNULL:!MD5;
-        add_header                      Set-Cookie "Path=/; HttpOnly; Secure; SameSite=strict";
-        add_header                      Cache-Control "no-store, no-cache, must-revalidate";
-        add_header                      Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self';" always;
-        add_header                      Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header                      X-Frame-Options DENY;
-        add_header                      X-Content-Type-Options nosniff;
-        add_header                      X-XSS-Protection "1; mode=block";
-        add_header                      Referrer-Policy "origin";
-
 
         access_log                      /dev/stdout json;
 
@@ -74,6 +65,7 @@ http {
         error_page 401 = @error401;
         location @error401 {
             limit_except      GET POST PUT { deny all; }
+            include /etc/includes/default-headers.conf;
             proxy_ssl_server_name on;
             proxy_ssl_verify_depth 2;
             return 302 /users/login?redirect=$request_uri;
@@ -86,6 +78,7 @@ http {
         location ~ ^/(403|404|500)$ {
             proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
             limit_except      GET POST PUT { deny all; }
+            include /etc/includes/default-headers.conf;
             proxy_ssl_server_name on;
             proxy_ssl_verify_depth 2;
             rewrite /(.*) /users/$1;
@@ -94,6 +87,8 @@ http {
         # Use API endpoint in user-service for checking authentication
         location /auth {
             limit_except      GET POST PUT { deny all; }
+            include /etc/includes/default-headers.conf;
+
             proxy_pass        https://$userservice/users/api/auth;
             proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
 
@@ -108,6 +103,7 @@ http {
         # Proxy for landing page to Bichard
         location = / {
             limit_except GET POST PUT DELETE { deny all; }
+            include /etc/includes/default-headers.conf;
             return 302 /users;
         }
 
@@ -116,6 +112,7 @@ http {
             limit_except GET POST PUT DELETE { deny all; }
             auth_request /auth;
             auth_request_set $auth_cookie $upstream_http_set_cookie;
+            include /etc/includes/default-headers.conf;
             add_header Set-Cookie $auth_cookie;
 
             proxy_pass        https://$app;
@@ -131,8 +128,8 @@ http {
             limit_except GET POST PUT DELETE { deny all; }
             auth_request /auth;
             auth_request_set $auth_cookie $upstream_http_set_cookie;
+            include /etc/includes/audit-logging-headers.conf;
             add_header Set-Cookie $auth_cookie;
-            add_header Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';" always;
 
             proxy_pass        https://$auditlogging;
             proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
@@ -149,6 +146,7 @@ http {
             limit_except GET POST PUT DELETE { deny all; }
             auth_request /auth;
             auth_request_set $auth_cookie $upstream_http_set_cookie;
+            include /etc/includes/default-headers.conf;
             add_header Set-Cookie $auth_cookie;
 
             proxy_pass        https://$userservice;
@@ -166,6 +164,7 @@ http {
             limit_except GET { deny all; }
             auth_request /auth;
             auth_request_set $auth_cookie $upstream_http_set_cookie;
+            include /etc/includes/default-headers.conf;
             add_header Set-Cookie $auth_cookie;
 
             proxy_pass        https://$staticservice;
@@ -179,6 +178,7 @@ http {
         # Proxy through to help files without auth
         location /help {
             limit_except GET { deny all; }
+            include /etc/includes/default-headers.conf;
 
             proxy_pass        https://$staticservice;
             proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
@@ -191,6 +191,7 @@ http {
         # Allow access to user-service login flow (and necessary assets) without authentication
         location ~ ^/users/(login|assets|_next/static|403|404|500)(.*)$ {
             limit_except GET POST PUT { deny all; }
+            include /etc/includes/default-headers.conf;
 
             proxy_pass        https://$userservice;
             proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
@@ -201,6 +202,7 @@ http {
 
         # Allow access to bichard-ui health check, connectivity and static endpoints without authentication
         location ~ ^/bichard-ui/(Health|Connectivity|images|css).*$ {
+            include /etc/includes/default-headers.conf;
             proxy_pass        https://$app;
             proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
             proxy_cookie_flags ~ httponly secure samesite=strict;
@@ -209,6 +211,7 @@ http {
         # Healthcheck endpoint
         location /elb-status {
             limit_except GET POST { deny all; }
+            include /etc/includes/default-headers.conf;
             access_log   off;
             return       200;
             add_header   Content-Type text/plain;

--- a/Nginx_Auth_Proxy/includes/audit-logging-headers.conf
+++ b/Nginx_Auth_Proxy/includes/audit-logging-headers.conf
@@ -1,0 +1,8 @@
+add_header  Set-Cookie "Path=/; HttpOnly; Secure; SameSite=strict";
+add_header  Cache-Control "no-store, no-cache, must-revalidate";
+add_header  Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header  X-Frame-Options DENY;
+add_header  X-Content-Type-Options nosniff;
+add_header  X-XSS-Protection "1; mode=block";
+add_header  Referrer-Policy "origin";
+add_header  Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';" always;

--- a/Nginx_Auth_Proxy/includes/default-headers.conf
+++ b/Nginx_Auth_Proxy/includes/default-headers.conf
@@ -1,0 +1,8 @@
+add_header  Set-Cookie "Path=/; HttpOnly; Secure; SameSite=strict";
+add_header  Cache-Control "no-store, no-cache, must-revalidate";
+add_header  Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header  X-Frame-Options DENY;
+add_header  X-Content-Type-Options nosniff;
+add_header  X-XSS-Protection "1; mode=block";
+add_header  Referrer-Policy "origin";
+add_header  Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self';" always;

--- a/Nginx_Auth_Proxy/includes/with-auth-headers.conf
+++ b/Nginx_Auth_Proxy/includes/with-auth-headers.conf
@@ -1,8 +1,8 @@
-add_header  Set-Cookie "Path=/; HttpOnly; Secure; SameSite=strict";
 add_header  Cache-Control "no-store, no-cache, must-revalidate";
 add_header  Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header  X-Frame-Options DENY;
 add_header  X-Content-Type-Options nosniff;
 add_header  X-XSS-Protection "1; mode=block";
 add_header  Referrer-Policy "origin";
+
 add_header  Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self';" always;

--- a/Nginx_Auth_Proxy/includes/without-auth-headers.conf
+++ b/Nginx_Auth_Proxy/includes/without-auth-headers.conf
@@ -5,4 +5,5 @@ add_header  X-Content-Type-Options nosniff;
 add_header  X-XSS-Protection "1; mode=block";
 add_header  Referrer-Policy "origin";
 
-add_header  Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';" always;
+add_header  Set-Cookie "Path=/; HttpOnly; Secure; SameSite=strict";
+add_header  Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self';" always;


### PR DESCRIPTION
This PR updates Nginx Auth Proxy template to use include directive for response headers.

Previously, we've been using `add_header` directive in `server` block for default headers that apply to all locations as well as in location blocks for specific headers to each location.

As mentioned in [Nginx documentation](http://nginx.org/en/docs/http/ngx_http_headers_module.html):
```
These directives are inherited from the previous configuration level if and only if there are no add_header directives defined on the current level.
```

This means that if we use `add_header` in a location block then all `add_header`s in the server block will be disregarded.
This PR fixes this issue by using `include` directive and  adding `includes/default-headers.conf` file containing default headers and including it in each location block.
There is also a separate file for audit logging headers as Content Security Policy is different from other locations.