### PR TITLE
fix: 🐛 bichard now outputs logs as json

### DIFF
--- a/Logstash/confd/templates/application.cloudwatch.conf.tmpl
+++ b/Logstash/confd/templates/application.cloudwatch.conf.tmpl
@@ -1,11 +1,5 @@
 input {
   cloudwatch_logs {
-    codec => multiline {
-      pattern => "^%{DATESTAMP} \[%{DATA:source}\] "
-      negate => true
-      what => "previous"
-      max_lines => 1000
-    }
     log_group => ["cjse-bichard7-{{ getv "/cjse/environment" ""}}-base-infra-bichard7"]
     start_position => "end"
     region => "eu-west-2"
@@ -20,20 +14,8 @@ filter {
   }
 
   json {
-      skip_on_invalid_json => true
       source => 'message'
       tag_on_failure => ['_jsonparsefailure']
-    }
-
-  grok {
-    patterns_dir => ["/etc/logstash/patterns"]
-    match => { 'message' => [
-      '%{JSON:obj_1}%{JSON:obj_2}%{GREEDYDATA:message}',
-      '%{DATESTAMP:datestamp} \[%{DATA:source}\] %{LOGLEVEL:loglevel} %{GREEDYDATA:message}',
-      '%{LOGLEVEL:loglevel} %{NOTSPACE:source} %{NOTSPACE:instance_ip} - ${WORD:code}: %{GREEDYDATA:stacktrace}\[%{GREEDYDATA:message}',
-      '%{LOGLEVEL:loglevel}%{SPACE}\] %{CODE:code}: %{GREEDYDATA:message}',
-      '%{LOGLEVEL:loglevel}%{SPACE}\] %{DATA:code}: %{GREEDYDATA:message}'
-    ] }
     }
   }
 


### PR DESCRIPTION
Because Bichard is outputting logs as json, we can simplify the logstash grok filter.