### PR TITLE
fix: 🐛 correct url for grafana web probes

### DIFF
--- a/Grafana/confd/templates/blackbox-endpoint-prober.json.tpl
+++ b/Grafana/confd/templates/blackbox-endpoint-prober.json.tpl
@@ -498,7 +498,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "probe_success{instance=\"https://bichard-web.{{getv "/cjse/infra/domain" "cjse.org"}}/bichard-ui/Health\"}",
+          "expr": "probe_success{instance=\"https://proxy.{{getv "/cjse/infra/domain" "cjse.org"}}/bichard-ui/Connectivity\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -712,7 +712,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "probe_success{instance=\"https://bichard-backend.{{getv "/cjse/infra/domain" "cjse.org"}}/bichard-ui/Connectivity\"}",
+          "expr": "probe_success{instance=\"https://proxy.{{getv "/cjse/infra/domain" "cjse.org"}}/bichard-backend/Connectivity\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/Prometheus/confd/templates/prometheus.yml.tpl
+++ b/Prometheus/confd/templates/prometheus.yml.tpl
@@ -60,8 +60,8 @@ scrape_configs:
         replacement: {{getv "/cjse/prometheus/blackbox/exporter/fqdn" "localhost"}}:9116
     static_configs:
       - targets:
-        - https://bichard-web.{{getv "/cjse/fqdn/suffix" "cjse.org"}}/bichard-ui/Connectivity
-        - https://bichard-backend.{{getv "/cjse/fqdn/suffix" "cjse.org"}}/bichard-ui/Connectivity
+        - https://proxy.{{getv "/cjse/fqdn/suffix" "cjse.org"}}/bichard-ui/Connectivity
+        - https://proxy.{{getv "/cjse/fqdn/suffix" "cjse.org"}}/bichard-backend/Connectivity
   - job_name: 'blackbox_http_auth'
     metrics_path: '/probe'
     scheme: 'https'


### PR DESCRIPTION
fix: 🐛 correct the urls in prometheus to go via proxy too