### PR TITLE
Build openJDK for x86 instead for arm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ packer.log
 Nginx_Auth_Proxy/test/node_modules
 logstash_conf/
 Logstash/goss.env
+ci.docker/

--- a/Openjdk_Jre11_Slim/Makefile
+++ b/Openjdk_Jre11_Slim/Makefile
@@ -5,7 +5,7 @@ image = openjdk-jre11-slim
 
 build:
 	set -e; \
-	docker build -t "$(image)" . ;\
+	docker build --platform linux/amd64 -t "$(image)" . ;\
 	if [[ "${SKIP_GOSS}x" == "truex" ]]; then \
 	  	echo "Skipping dgoss tests"; \
 	else \


### PR DESCRIPTION
The reason for this was using arm and building the docker images it was pulling in all the arm images which didn't exist.

