### PR TITLE
Set terraform version to 1.1.9

### DIFF
--- a/Codebuild_Base/scripts/build_docker.sh
+++ b/Codebuild_Base/scripts/build_docker.sh
@@ -4,7 +4,8 @@ set -e
 
 export readonly REPOSITORY_NAME="codebuild-base"
 export readonly SOURCE_REPOSITORY_NAME="nodejs"
-LATEST_TERRAFORM_CLI_VERSION=$(curl --silent -L https://github.com/hashicorp/terraform/releases/latest -w %\{url_effective\} | tail -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')
+
+LATEST_TERRAFORM_CLI_VERSION="1.1.9"
 export BUILD_ARGS="--build-arg TERRAFORM_VERSION=${LATEST_TERRAFORM_CLI_VERSION}"
 
 /bin/bash ../scripts/build_and_push_image.sh


### PR DESCRIPTION
Terraform deployment fails when using the latest version 1.2
