### PR TITLE
Make Nginx logs valid JSON by removing extra quote

### DIFF
--- a/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/nginx.conf.tpl
@@ -28,7 +28,7 @@ http {
         '"@timestamp": "$time_iso8601", '
         '"message": "$remote_addr - $remote_user [$time_local] \\\"$request\\\" $status $body_bytes_sent \\\"$http_referer\\\" \\\"$http_user_agent\\\"", '
         '"tags": ["nginx_access"], '
-        '"realip": ""$remote_addr", '
+        '"realip": "$remote_addr", '
         '"proxyip": "$http_x_forwarded_for", '
         '"remote_user": "$remote_user", '
         '"contenttype": "$sent_http_content_type", '

--- a/Nginx_Java_Supervisord/conf/nginx.conf
+++ b/Nginx_Java_Supervisord/conf/nginx.conf
@@ -28,7 +28,7 @@ http {
         '"@timestamp": "$time_iso8601", '
         '"message": "$remote_addr - $remote_user [$time_local] \\\"$request\\\" $status $body_bytes_sent \\\"$http_referer\\\" \\\"$http_user_agent\\\"", '
         '"tags": ["nginx_access"], '
-        '"realip": ""$remote_addr", '
+        '"realip": "$remote_addr", '
         '"proxyip": "$http_x_forwarded_for", '
         '"remote_user": "$remote_user", '
         '"contenttype": "$sent_http_content_type", '

--- a/Nginx_NodeJS_Supervisord/conf/nginx.conf
+++ b/Nginx_NodeJS_Supervisord/conf/nginx.conf
@@ -28,7 +28,7 @@ http {
         '"@timestamp": "$time_iso8601", '
         '"message": "$remote_addr - $remote_user [$time_local] \\\"$request\\\" $status $body_bytes_sent \\\"$http_referer\\\" \\\"$http_user_agent\\\"", '
         '"tags": ["nginx_access"], '
-        '"realip": ""$remote_addr", '
+        '"realip": "$remote_addr", '
         '"proxyip": "$http_x_forwarded_for", '
         '"remote_user": "$remote_user", '
         '"contenttype": "$sent_http_content_type", '

--- a/Nginx_Supervisord/confd/templates/nginx.conf.tpl
+++ b/Nginx_Supervisord/confd/templates/nginx.conf.tpl
@@ -28,7 +28,7 @@ http {
         '"@timestamp": "$time_iso8601", '
         '"message": "$remote_addr - $remote_user [$time_local] \\\"$request\\\" $status $body_bytes_sent \\\"$http_referer\\\" \\\"$http_user_agent\\\"", '
         '"tags": ["nginx_access"], '
-        '"realip": ""$remote_addr", '
+        '"realip": "$remote_addr", '
         '"proxyip": "$http_x_forwarded_for", '
         '"remote_user": "$remote_user", '
         '"contenttype": "$sent_http_content_type", '

--- a/Prometheus/conf/nginx.conf
+++ b/Prometheus/conf/nginx.conf
@@ -28,7 +28,7 @@ http {
         '"@timestamp": "$time_iso8601", '
         '"message": "$remote_addr - $remote_user [$time_local] \\\"$request\\\" $status $body_bytes_sent \\\"$http_referer\\\" \\\"$http_user_agent\\\"", '
         '"tags": ["nginx_access"], '
-        '"realip": ""$remote_addr", '
+        '"realip": "$remote_addr", '
         '"proxyip": "$http_x_forwarded_for", '
         '"remote_user": "$remote_user", '
         '"contenttype": "$sent_http_content_type", '

--- a/Prometheus_BlackBox_Exporter/conf/nginx.conf
+++ b/Prometheus_BlackBox_Exporter/conf/nginx.conf
@@ -28,7 +28,7 @@ http {
         '"@timestamp": "$time_iso8601", '
         '"message": "$remote_addr - $remote_user [$time_local] \\\"$request\\\" $status $body_bytes_sent \\\"$http_referer\\\" \\\"$http_user_agent\\\"", '
         '"tags": ["nginx_access"], '
-        '"realip": ""$remote_addr", '
+        '"realip": "$remote_addr", '
         '"proxyip": "$http_x_forwarded_for", '
         '"remote_user": "$remote_user", '
         '"contenttype": "$sent_http_content_type", '

--- a/Prometheus_Cloudwatch_Exporter/conf/nginx.conf
+++ b/Prometheus_Cloudwatch_Exporter/conf/nginx.conf
@@ -28,7 +28,7 @@ http {
         '"@timestamp": "$time_iso8601", '
         '"message": "$remote_addr - $remote_user [$time_local] \\\"$request\\\" $status $body_bytes_sent \\\"$http_referer\\\" \\\"$http_user_agent\\\"", '
         '"tags": ["nginx_access"], '
-        '"realip": ""$remote_addr", '
+        '"realip": "$remote_addr", '
         '"proxyip": "$http_x_forwarded_for", '
         '"remote_user": "$remote_user", '
         '"contenttype": "$sent_http_content_type", '


### PR DESCRIPTION
There was a small little typo in the JSON output specification for the Nginx logs:

```
"realip": ""$remote_addr",
```

This has meant that the logs coming out of Nginx have never been valid JSON:

```
"realip": ""10.128.3.218",
```

It then seems that this typo was copied and pasted between all of the containers that run Nginx (which is quite a few of them!).

This PR removes the extra quote from all the places I could find it, which should make the logs valid JSON again.