### PR TITLE
feat: 🎸 new comparison dashboard

### DIFF
--- a/Grafana/confd/conf.d/comparison-dashboard.toml
+++ b/Grafana/confd/conf.d/comparison-dashboard.toml
@@ -1,0 +1,8 @@
+[template]
+src = "comparison-dashboard.json.tpl"
+dest = "/opt/grafana/dashboards/comparison-dashboard.json"
+keys = [
+    "/cjse"
+]
+gid = 998
+uid = 999

--- a/Grafana/confd/templates/comparison-dashboard.json.tpl
+++ b/Grafana/confd/templates/comparison-dashboard.json.tpl
@@ -44,7 +44,30 @@
             }
           },
         },
-        "overrides": []
+        "overrides": [
+          {
+          "matcher": {
+            "id": "byName",
+            "options": "{__name__=\"logmetrics_comparison_result_pass_sum\", job=\"logmetrics\"}"
+          },
+          "properties": [
+            {
+              "id": "displayName",
+              "value": "passed"
+            }
+          ]
+        },
+        {
+          "matcher": {
+            "id": "byName",
+            "options": "{__name__=\"logmetrics_comparison_result_fail_sum\", job=\"logmetrics\"}"
+          },
+          "properties": [
+            {
+              "id": "displayName",
+              "value": "failed"
+            }
+        ]
       },
       "gridPos": {
         "h": 9,
@@ -62,7 +85,7 @@
             "percent"
           ]
         },
-        "pieType": "pie",
+        "pieType": "donut",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -87,6 +110,7 @@
         }
       ],
       "title": "Sum of total comparison pass / fail",
+      "transparent": true,
       "type": "piechart"
     }
   ],

--- a/Grafana/confd/templates/comparison-dashboard.json.tpl
+++ b/Grafana/confd/templates/comparison-dashboard.json.tpl
@@ -1,0 +1,108 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "pallette-classic"
+          },
+          "mappings": [],
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.5.6",
+      "targets": [
+        {
+          "expr": "logmetrics_comparison_result_pass_sum{}",
+          "refId": "A"
+        },
+        {
+          "expr": "logmetrics_comparison_result_fail_sum{}",
+          "refId": "B"
+        }
+      ],
+      "title": "Sum of total comparison pass / fail",
+      "type": "piechart"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Comparison results",
+  "version": 0,
+}


### PR DESCRIPTION
Sets up a new dashboard to display the comparison lambda results. Currently, its is configured to display a pail chart of passes vs fails, it's fairly straight forward to change the graph if we want to display the info in a different way.

![image](https://user-images.githubusercontent.com/29051079/178532130-f08fff12-28ec-4a71-af78-088d62ed4e0f.png)
