### PR TITLE
chore: 🤖 bump logstash version and ignore upstream vulns

### DIFF
--- a/Logstash/Dockerfile
+++ b/Logstash/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /
 COPY ./files/logstash.repo /etc/yum.repos.d
 COPY scripts/credentials.sh /usr/bin/credentials
 # This must match what is deployed on AWS
-ARG LOGSTASH_VERSION="7.16.2"
+ARG LOGSTASH_VERSION="7.17.5"
 ARG CONFD_VERSION="0.16.0"
 ARG CONFD_CHECKSUM="255d2559f3824dd64df059bdc533fd6b697c070db603c76aaf8d1d5e6b0cc334"
 

--- a/scripts/.trivyignore
+++ b/scripts/.trivyignore
@@ -1,2 +1,5 @@
 # Waiting for upstream prometheus/ promtool to patch the vulnerability for "go-restful"
 CVE-2022-1996
+# Ruby (gemspec) vulnerabilities for logstash container
+CVE-2022-25648 # git
+CVE-2020-14001 # kramdown


### PR DESCRIPTION
Trivy picked up some critical vulnerabilities in upstream logstash Ruby gemspec bumping logstash to the latest version got rid of some but not all of the vulnerabilities, ignore the ones that aren't fixed upstream.