### PR TITLE
Bicaws 2177 daily comparison pass percentage metric and graph

### DIFF
--- a/Grafana/confd/templates/comparison-dashboard.json.tpl
+++ b/Grafana/confd/templates/comparison-dashboard.json.tpl
@@ -121,6 +121,84 @@
               }
             ],
             "type": "piechart"
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        }
+                    },
+                    "mappings": []
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "logmetrics_comparison_total_passed_percentage_sum{job=\"logmetrics\"}"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "passed"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 0
+            },
+            "id": 4,
+            "options": {
+                "legend": {
+                    "displayMode": "list",
+                    "placement": "bottom"
+                },
+                "pieType": "pie",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "expr": "logmetrics_comparison_total_passed_percentage_sum{}",
+                    "refId": "A"
+                }
+            ],
+            "title": "Passed percentage of all comparison results",
+            "transformations": [
+              {
+                "id": "reduce",
+                "options": {
+                  "includeTimeField": false,
+                  "labelsToFields": false,
+                  "mode": "reduceFields",
+                  "reducers": [
+                    "max"
+                  ]
+                }
+              }
+            ],
+            "type": "piechart"
         }
     ],
     "refresh": "",

--- a/Prometheus_Cloudwatch_Exporter/conf/config.yml
+++ b/Prometheus_Cloudwatch_Exporter/conf/config.yml
@@ -276,4 +276,7 @@ metrics:
 
   - aws_namespace: LogMetrics
     aws_metric_name: StoreEventS3ObjectNotFound
+
+  - aws_namespace: LogMetrics
+    aws_metric_name: ComparisonTotalPassedPercentage
 ...


### PR DESCRIPTION
This PR adds `LogMetrics/ComparisonTotalPassedPercentage` to Cloudwatch exporter and a new graph to Grafana.