### PR TITLE
Ignore logstash vuln

### DIFF
--- a/Logstash/confd/templates/user-service.cloudwatch.conf.tmpl
+++ b/Logstash/confd/templates/user-service.cloudwatch.conf.tmpl
@@ -12,6 +12,7 @@ filter {
   mutate{
       replace => [ "message", "%{message}" ]
       gsub => [ 'message','\n','']
+      gsub => [ 'message','\"\"([^,])','"\1'] # nginx logs were malformed with an extra " on the realip key
   }
 
   json {

--- a/Logstash/confd/templates/user-service.cloudwatch.conf.tmpl
+++ b/Logstash/confd/templates/user-service.cloudwatch.conf.tmpl
@@ -12,7 +12,6 @@ filter {
   mutate{
       replace => [ "message", "%{message}" ]
       gsub => [ 'message','\n','']
-      gsub => [ 'message','\"\"([^,])','"\1'] # nginx logs were malformed with an extra " on the realip key
   }
 
   json {

--- a/Openjdk_Jre11_Slim/Dockerfile
+++ b/Openjdk_Jre11_Slim/Dockerfile
@@ -19,11 +19,11 @@ RUN { echo '#/bin/sh'; echo 'echo "$JAVA_HOME"'; } > /usr/local/bin/docker-java-
 
 ENV PATH $JAVA_HOME/bin:$PATH
 ENV LANG C.UTF-8
-ENV JAVA_VERSION 11.0.10
+ENV JAVA_VERSION 11.0.16
 
 # hadolint ignore=SC2016
 RUN set -euvx && \
-	downloadUrl='https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jre_x64_linux_11.0.10_9.tar.gz' && \
+	downloadUrl='https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.16%2B8/OpenJDK11U-jre_x64_linux_11.0.16_8.tar.gz' && \
 	wget --progress=dot:giga -O openjdk.tgz "$downloadUrl" && \
 	wget --progress=dot:giga -O openjdk.tgz.asc "$downloadUrl.sign" && \
 	export GNUPGHOME="$(mktemp -d)" && \

--- a/Openjdk_Jre11_Slim/goss.yaml
+++ b/Openjdk_Jre11_Slim/goss.yaml
@@ -25,7 +25,7 @@ user:
     uid: 99
     gid: 99
     groups:
-    - nobody
+      - nobody
     home: /
     shell: /sbin/nologin
 command:
@@ -33,7 +33,7 @@ command:
     exit-status: 0
     stdout: []
     stderr:
-    - openjdk version "11.0.10" 2021-01-19
-    - OpenJDK Runtime Environment 18.9 (build 11.0.10+9)
-    - OpenJDK 64-Bit Server VM 18.9 (build 11.0.10+9, mixed mode, sharing)
+      - openjdk version "11.0.16"
+      - OpenJDK Runtime Environment 18.9 (build 11.0.16+8)
+      - OpenJDK 64-Bit Server VM 18.9 (build 11.0.16+8, mixed mode, sharing)
     timeout: 10000

--- a/scripts/.trivyignore
+++ b/scripts/.trivyignore
@@ -3,3 +3,5 @@ CVE-2022-1996
 # Ruby (gemspec) vulnerabilities for logstash container
 CVE-2022-25648 # git
 CVE-2020-14001 # kramdown
+# Logstash container vulnerability xalan:xalan (OpenJDK: integer truncation issue in Xalan-J (JAXP, 8285407)) The Apache Xalan Java project is dormant and in the process of being retired. No future releases of Apache Xalan Java to address this issue are expected. Note: Java runtimes (such as OpenJDK) include repackaged copies of Xalan.
+CVE-2022-34169


### PR DESCRIPTION
- Ignore the logstash vulnerability for xalan as it is building on top of am2 and not from our open jdk image as first suspected
- Bump the openjdk image version from `11.0.10` -> `11.0.16` (this is the base image for `nginx-java-supervisord` which used for the `prometheus, prometheus-cloudwatch-exporter and promethueus-blackbox-exporter` images)