### PR TITLE
chore: 🤖 increase timeout for audit log api

### DIFF
--- a/Grafana/confd/templates/lambdas-dashboard.json.tpl
+++ b/Grafana/confd/templates/lambdas-dashboard.json.tpl
@@ -731,12 +731,15 @@
     },
     {
       "alert": {
-        "alertRuleTags": {},
+        "alertRuleTags": {
+          "service": "Audit Log API",
+          "severity": "warning"
+        },
         "conditions": [
           {
             "evaluator": {
               "params": [
-                0
+                0.2
               ],
               "type": "gt"
             },
@@ -746,7 +749,7 @@
             "query": {
               "params": [
                 "A",
-                "5m",
+                "10m",
                 "now"
               ]
             },
@@ -758,7 +761,7 @@
           }
         ],
         "executionErrorState": "alerting",
-        "for": "5m",
+        "for": "10m",
         "frequency": "1m",
         "handler": 1,
         "message": "Error in Audit Log API lambdas",


### PR DESCRIPTION
- This tweaks the Prometheus alert so that is it does not 200 for more than 2 mins out of 10 we will raise an alert