### PR TITLE
Bicaws 2222 add graph for ALB target response time

### DIFF
--- a/Grafana/confd/templates/main-dashboard.json.tpl
+++ b/Grafana/confd/templates/main-dashboard.json.tpl
@@ -1319,7 +1319,7 @@
               "refId": "A",
               "editorMode": "code",
               "expr": "max(aws_applicationelb_target_response_time_p99_00{load_balancer=~\".*-bichard-7-nginx.*\"})",
-              "legendFormat": "",
+              "legendFormat": "Max response time",
               "range": true,
               "rawQuery": true,
               "hide": false
@@ -1328,7 +1328,7 @@
               "refId": "B",
               "editorMode": "code",
               "expr": "avg(aws_applicationelb_target_response_time_average{load_balancer=~\".*-bichard-7-nginx.*\"})",
-              "legendFormat": "",
+              "legendFormat": "Average response time",
               "range": true,
               "rawQuery": true,
               "hide": false

--- a/Grafana/confd/templates/main-dashboard.json.tpl
+++ b/Grafana/confd/templates/main-dashboard.json.tpl
@@ -1303,6 +1303,99 @@
             ],
             "title": "Event Handler Failures",
             "type": "timeseries"
+        },
+        {
+          "id": 47,
+          "gridPos": {
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 8
+          },
+          "type": "timeseries",
+          "title": "Web response time(response time from nginx auth proxy)",
+          "targets": [
+            {
+              "refId": "A",
+              "editorMode": "code",
+              "expr": "max(aws_applicationelb_target_response_time_p99_00{load_balancer=~\".*-bichard-7-nginx.*\"})",
+              "legendFormat": "",
+              "range": true,
+              "rawQuery": true,
+              "hide": false
+            },
+            {
+              "refId": "B",
+              "editorMode": "code",
+              "expr": "avg(aws_applicationelb_target_response_time_average{load_balancer=~\".*-bichard-7-nginx.*\"})",
+              "legendFormat": "",
+              "range": true,
+              "rawQuery": true,
+              "hide": false
+            }
+          ],
+          "options": {
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "calcs": []
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "barAlignment": 0,
+                "lineWidth": 1,
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "spanNulls": false,
+                "showPoints": "auto",
+                "pointSize": 5,
+                "stacking": {
+                  "mode": "none",
+                  "group": "A"
+                },
+                "axisPlacement": "auto",
+                "axisLabel": "",
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "hideFrom": {
+                  "tooltip": false,
+                  "viz": false,
+                  "legend": false
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "value": null,
+                    "color": "green"
+                  },
+                  {
+                    "value": 80,
+                    "color": "red"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "datasource": null
         }
     ],
     "refresh": "10s",

--- a/Prometheus_Cloudwatch_Exporter/conf/config.yml
+++ b/Prometheus_Cloudwatch_Exporter/conf/config.yml
@@ -78,6 +78,8 @@ metrics:
   - aws_namespace: AWS/ApplicationELB
     aws_metric_name: TargetResponseTime
     aws_dimensions: [LoadBalancer, AvailabilityZone, TargetGroup]
+    aws_statistics: [Average]
+    aws_extended_statistics: [p99.00]
 
   - aws_namespace: AWS/NetworkELB
     aws_metric_name: HealthyHostCount

--- a/Prometheus_Cloudwatch_Exporter/conf/config.yml
+++ b/Prometheus_Cloudwatch_Exporter/conf/config.yml
@@ -75,6 +75,10 @@ metrics:
     aws_metric_name: HTTPCode_Target_5XX_Count
     aws_dimensions: [LoadBalancer, AvailabilityZone, TargetGroup]
 
+  - aws_namespace: AWS/ApplicationELB
+    aws_metric_name: TargetResponseTime
+    aws_dimensions: [LoadBalancer, AvailabilityZone, TargetGroup]
+
   - aws_namespace: AWS/NetworkELB
     aws_metric_name: HealthyHostCount
     aws_dimensions: [LoadBalancer, TargetGroup]


### PR DESCRIPTION
This is to monitor the time elapsed after a request leaves the load balancer until a response from the target is received, so we know if B7 is slow. 
Metrics used:
- Average target response time
- p99.00 / percentiles (worst case for 99% of the users)

![image](https://user-images.githubusercontent.com/22743709/185966945-1934a479-8f7d-4828-9ae4-af5063eaabe6.png)
