### PR TITLE
Update content-security-policy for new UI

### DIFF
--- a/Nginx_Auth_Proxy/confd/templates/bichard.http.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/bichard.http.conf.tpl
@@ -87,6 +87,9 @@ location /bichard {
     proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
     proxy_set_header Host $http_host;
 
+    # New Bichard UI sets it's own CSP before it reaches nginx
+    proxy_pass_header Content-Security-Policy;
+
     proxy_intercept_errors on;
 }
 

--- a/Nginx_Auth_Proxy/confd/templates/bichard.http.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/bichard.http.conf.tpl
@@ -80,7 +80,7 @@ location /bichard {
     limit_except GET POST PUT DELETE { deny all; }
     auth_request /auth;
     auth_request_set $auth_cookie $upstream_http_set_cookie;
-    include /etc/includes/headers.conf;
+    include /etc/includes/ui-headers.conf;
     add_header Set-Cookie $auth_cookie;
 
     proxy_pass        https://$ui;

--- a/Nginx_Auth_Proxy/confd/templates/bichard.https.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/bichard.https.conf.tpl
@@ -88,7 +88,7 @@ location /bichard {
     auth_request /auth;
     auth_request_set $auth_cookie $upstream_http_set_cookie;
     add_header  Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    include /etc/includes/headers.conf;
+    include /etc/includes/ui-headers.conf;
     add_header Set-Cookie "$auth_cookie; secure";
 
     proxy_pass        https://$ui;

--- a/Nginx_Auth_Proxy/confd/templates/bichard.https.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/bichard.https.conf.tpl
@@ -94,6 +94,8 @@ location /bichard {
     proxy_pass        https://$ui;
     proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
     proxy_set_header Host $http_host;
+    
+    # New Bichard UI sets it's own CSP before it reaches nginx
     proxy_pass_header Content-Security-Policy;
 
     proxy_intercept_errors on;

--- a/Nginx_Auth_Proxy/confd/templates/bichard.https.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/bichard.https.conf.tpl
@@ -94,6 +94,7 @@ location /bichard {
     proxy_pass        https://$ui;
     proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
     proxy_set_header Host $http_host;
+    proxy_pass_header Content-Security-Policy;
 
     proxy_intercept_errors on;
 }

--- a/Nginx_Auth_Proxy/includes/ui-headers.conf
+++ b/Nginx_Auth_Proxy/includes/ui-headers.conf
@@ -3,8 +3,3 @@ add_header  X-Frame-Options DENY;
 add_header  X-Content-Type-Options nosniff;
 add_header  X-XSS-Protection "1; mode=block";
 add_header  Referrer-Policy "origin";
-
-sub_filter_once off;
-sub_filter random-csp-nonce $request_id;
-
-add_header  Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'; style-src 'self' 'nonce-$request_id'" always;

--- a/Nginx_Auth_Proxy/includes/ui-headers.conf
+++ b/Nginx_Auth_Proxy/includes/ui-headers.conf
@@ -1,0 +1,7 @@
+add_header  Cache-Control "no-store, no-cache, must-revalidate";
+add_header  X-Frame-Options DENY;
+add_header  X-Content-Type-Options nosniff;
+add_header  X-XSS-Protection "1; mode=block";
+add_header  Referrer-Policy "origin";
+
+add_header  Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';" always;

--- a/Nginx_Auth_Proxy/includes/ui-headers.conf
+++ b/Nginx_Auth_Proxy/includes/ui-headers.conf
@@ -4,4 +4,7 @@ add_header  X-Content-Type-Options nosniff;
 add_header  X-XSS-Protection "1; mode=block";
 add_header  Referrer-Policy "origin";
 
-add_header  Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';" always;
+sub_filter_once off;
+sub_filter random-csp-nonce $request_id;
+
+add_header  Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'; style-src 'self' 'nonce-$request_id'" always;

--- a/Nginx_Auth_Proxy/test/package-lock.json
+++ b/Nginx_Auth_Proxy/test/package-lock.json
@@ -3546,13 +3546,13 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.1.tgz",
-      "integrity": "sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
       "dev": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.3",
+        "fetch-blob": "^3.1.4",
         "formdata-polyfill": "^4.0.10"
       },
       "engines": {
@@ -7390,13 +7390,13 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.1.tgz",
-      "integrity": "sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
       "dev": true,
       "requires": {
         "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.3",
+        "fetch-blob": "^3.1.4",
         "formdata-polyfill": "^4.0.10"
       }
     },


### PR DESCRIPTION
Currently, the new UI crashes when running behind the Nginx-auth-proxy because some of the client site JS violates the content security policy
![image](https://user-images.githubusercontent.com/22743709/190457777-847b511d-d433-4e9e-b926-6d79d0360342.png)

