### PR TITLE
chore: 🤖 bump period up to 15mins for grafana and opensearch

### DIFF
--- a/Grafana/confd/templates/blackbox-endpoint-prober.json.tpl
+++ b/Grafana/confd/templates/blackbox-endpoint-prober.json.tpl
@@ -393,7 +393,7 @@
           {
             "evaluator": {
               "params": [
-                0.2
+                0.1
               ],
               "type": "lt"
             },
@@ -753,7 +753,7 @@
             "query": {
               "params": [
                 "A",
-                "10m",
+                "15m",
                 "now"
               ]
             },
@@ -972,7 +972,7 @@
           {
             "evaluator": {
               "params": [
-                0.2
+                0.1
               ],
               "type": "lt"
             },
@@ -982,7 +982,7 @@
             "query": {
               "params": [
                 "A",
-                "10m",
+                "15m",
                 "now"
               ]
             },


### PR DESCRIPTION
Another tweak to quieten the noisy alerts during prod deploys

* bump the period of the alert up to 15 mins for opensearch and grafana
* increase the trigger threshold for the web probe to 9 mins out of 10