### PR TITLE
Update node to version 16.13.1 in NodeJS docker file

### DIFF
--- a/Codebuild_Base/goss.yaml
+++ b/Codebuild_Base/goss.yaml
@@ -51,7 +51,7 @@ command:
   node --version:
     exit-status: 0
     stdout:
-      - v16.12.0
+      - v16.13.1
   pip3 list:
     exit-status: 0
     stdout:

--- a/NodeJS/Dockerfile
+++ b/NodeJS/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="CJSE"
 ARG NODE_USER="node"
 ARG NODE_GUID=1000
 ARG ARCH="x64"
-ARG NODE_VERSION="16.12.0"
+ARG NODE_VERSION="16.13.1"
 ARG YARN_VERSION="1.22.15"
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/

--- a/NodeJS/goss.yaml
+++ b/NodeJS/goss.yaml
@@ -37,7 +37,7 @@ command:
   node --version:
     exit-status: 0
     stdout:
-      - v16.12.0
+      - v16.13.1
     stderr: []
     timeout: 10000
   yarn --version:


### PR DESCRIPTION
Update node version in NodeJS docker file to match our lambdas' node version.

This ensures that our CodeBuild jobs use the same node version as our development environment.