### PR TITLE
Bump node version

### DIFF
--- a/Codebuild_Base/goss.yaml
+++ b/Codebuild_Base/goss.yaml
@@ -51,7 +51,7 @@ command:
   node --version:
     exit-status: 0
     stdout:
-      - v16.12.0
+      - v16.18.1
   pip3 list:
     exit-status: 0
     stdout:

--- a/NodeJS/Dockerfile
+++ b/NodeJS/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="CJSE"
 ARG NODE_USER="node"
 ARG NODE_GUID=1000
 ARG ARCH="x64"
-ARG NODE_VERSION="16.12.0"
+ARG NODE_VERSION="16.16.0"
 ARG YARN_VERSION="1.22.15"
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/

--- a/NodeJS/Dockerfile
+++ b/NodeJS/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="CJSE"
 ARG NODE_USER="node"
 ARG NODE_GUID=1000
 ARG ARCH="x64"
-ARG NODE_VERSION="16.16.0"
+ARG NODE_VERSION="16.18.1"
 ARG YARN_VERSION="1.22.15"
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/

--- a/NodeJS/goss.yaml
+++ b/NodeJS/goss.yaml
@@ -37,7 +37,7 @@ command:
   node --version:
     exit-status: 0
     stdout:
-      - v16.12.0
+      - v16.18.1
     stderr: []
     timeout: 10000
   yarn --version:


### PR DESCRIPTION
UI trivy highlighted a critical vulnerability for loader-utils in the Node.js image, unfortunately bumping the version didn't solve the error but is worth doing anyway.