### PR TITLE
fix: 🐛 get latest v8 for grafana

### DIFF
--- a/Grafana/scripts/build_docker.sh
+++ b/Grafana/scripts/build_docker.sh
@@ -5,7 +5,7 @@ set -ex
 export readonly REPOSITORY_NAME="grafana"
 export readonly SOURCE_REPOSITORY_NAME="amazon-linux2-base"
 export GOSS_ENV="-e ALERTMANAGER_URL=localhost"
-LATEST_GRAFANA_VERSION=$(curl --silent https://github.com/grafana/grafana/releases | grep /tag/v8 | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')
+LATEST_GRAFANA_VERSION=$(curl --silent "https://api.github.com/repos/grafana/grafana/releases" | jq -c '[.[] | select(.tag_name | contains("v8"))][0].tag_name' | sed -r 's/^"v(.*)"$/\1/')
 LATEST_CONFD_VERSION=$(curl --silent -L https://github.com/kelseyhightower/confd/releases/latest -w %\{url_effective\} | tail -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')
 export BUILD_ARGS="--build-arg GRAFANA_VERSION=${LATEST_GRAFANA_VERSION} --build-arg CONFD_VERSION=${LATEST_CONFD_VERSION}"
 

--- a/Grafana_Codebuild/scripts/build_docker.sh
+++ b/Grafana_Codebuild/scripts/build_docker.sh
@@ -4,7 +4,7 @@ set -ex
 
 export readonly REPOSITORY_NAME="grafana-codebuild"
 export readonly SOURCE_REPOSITORY_NAME="amazon-linux2-base"
-LATEST_GRAFANA_VERSION=$(curl --silent https://github.com/grafana/grafana/releases | grep /tag/v8 | head -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')
+LATEST_GRAFANA_VERSION=$(curl --silent "https://api.github.com/repos/grafana/grafana/releases" | jq -c '[.[] | select(.tag_name | contains("v8"))][0].tag_name' | sed -r 's/^"v(.*)"$/\1/')
 LATEST_CONFD_VERSION=$(curl --silent -L https://github.com/kelseyhightower/confd/releases/latest -w %\{url_effective\} | tail -1 | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')
 export BUILD_ARGS="--build-arg GRAFANA_VERSION=${LATEST_GRAFANA_VERSION} --build-arg CONFD_VERSION=${LATEST_CONFD_VERSION}"
 


### PR DESCRIPTION
Grafana version 8 was pushed off of the first page of releases so we needed to change how we get the latest version 8