### PR TITLE
Update build scripts to build for arm

### DIFF
--- a/Amazon_Linux_Base/Dockerfile
+++ b/Amazon_Linux_Base/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BUILD_IMAGE}
 
 LABEL maintainer="CJSE"
 ARG YUM_PACKAGES="python-pip gzip tar unzip openssl shadow-utils xz wget gnupg"
-ARG PIP_PACKAGES="awscli jq"
+ARG PIP_PACKAGES="awscli"
 
 RUN yum update -y && \
     amazon-linux-extras install -y epel && \

--- a/Amazon_Linux_Base/Makefile
+++ b/Amazon_Linux_Base/Makefile
@@ -1,13 +1,5 @@
 SHELL := /bin/bash # Use bash syntax
 .PHONY: build
 
-image = amazon-linux2-base
-
 build:
-	set -e; \
-	docker build --platform linux/amd64 -t "$(image)" . ;\
-	if [[ "${SKIP_GOSS}x" == "truex" ]]; then \
-	  echo "Skipping dgoss tests"; \
-	else \
-		GOSS_SLEEP=15 dgoss run $(image); \
-	fi
+	bash build.sh

--- a/Amazon_Linux_Base/build.sh
+++ b/Amazon_Linux_Base/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+IMAGE="amazon-linux2-base"
+
+if [ "${PLATFORM}x" = "arm64x" ]; then
+  docker build --platform linux/${PLATFORM} -t "${IMAGE}:arm" . 
+else
+  docker build -t $IMAGE . 
+fi
+
+if [[ "${SKIP_GOSS}x" == "truex" ]]; then
+  echo "Skipping dgoss tests"
+else
+  GOSS_SLEEP=15 dgoss run $IMAGE
+fi

--- a/Nginx_Auth_Proxy/Makefile
+++ b/Nginx_Auth_Proxy/Makefile
@@ -12,7 +12,7 @@ build-and-run: build run-test-nginx
 
 .PHONY: build
 build:
-	docker build --platform linux/amd64 -t "$(image)" .
+	bash build.sh
 
 .PHONY: goss
 goss:

--- a/Nginx_Auth_Proxy/build.sh
+++ b/Nginx_Auth_Proxy/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+IMAGE="nginx-auth-proxy"
+
+if [ "${PLATFORM}x" = "arm64x" ]; then
+  docker build --platform linux/${PLATFORM} --build-arg BUILD_IMAGE=amazon-linux2-base:arm --build-arg ARCH=arm64 -t "${IMAGE}:arm" . 
+else
+  docker build -t $IMAGE . 
+fi

--- a/Nginx_Java_Supervisord/Makefile
+++ b/Nginx_Java_Supervisord/Makefile
@@ -4,10 +4,4 @@ SHELL := /bin/bash # Use bash syntax
 image = nginx-java-supervisord
 
 build:
-	set -e; \
-	docker build -t "$(image)" . ;\
-	if [[ "${SKIP_GOSS}x" == "truex" ]]; then \
-  		echo "Skipping dgoss tests"; \
-	else \
-		GOSS_SLEEP=15 dgoss run $(image); \
-	fi
+	bash build.sh

--- a/Nginx_Java_Supervisord/build.sh
+++ b/Nginx_Java_Supervisord/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+IMAGE="nginx-java-supervisord"
+
+if [ "${PLATFORM}x" = "arm64x" ]; then
+  docker build --platform linux/${PLATFORM} --build-arg BUILD_IMAGE=openjdk-jre11-slim:arm -t "${IMAGE}:arm" . 
+else
+  docker build -t $IMAGE . 
+fi
+
+if [[ "${SKIP_GOSS}x" == "truex" ]]; then
+  echo "Skipping dgoss tests"
+else
+  GOSS_SLEEP=15 dgoss run $IMAGE
+fi

--- a/Nginx_NodeJS_Supervisord/Makefile
+++ b/Nginx_NodeJS_Supervisord/Makefile
@@ -1,13 +1,5 @@
 SHELL := /bin/bash # Use bash syntax
 .PHONY: build
 
-image = nginx-nodejs-supervisord
-
 build:
-	set -e; \
-	docker build --platform linux/amd64 -t "$(image)" . ;\
-	if [[ "${SKIP_GOSS}x" == "truex" ]]; then \
-  		echo "Skipping dgoss tests"; \
-	else \
-		GOSS_SLEEP=15 dgoss run $(image); \
-	fi
+	bash build.sh

--- a/Nginx_NodeJS_Supervisord/build.sh
+++ b/Nginx_NodeJS_Supervisord/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+IMAGE="nginx-nodejs-supervisord"
+
+if [ "${PLATFORM}x" = "arm64x" ]; then
+  docker build --platform linux/${PLATFORM} --build-arg BUILD_IMAGE=nodejs:arm --build-arg ARCH=arm64 -t "${IMAGE}:arm" . 
+else
+  docker build -t $IMAGE . 
+fi
+
+if [[ "${SKIP_GOSS}x" == "truex" ]]; then
+    echo "Skipping dgoss tests"
+else
+  GOSS_SLEEP=15 dgoss run $IMAGE
+fi

--- a/Nginx_Supervisord/Dockerfile
+++ b/Nginx_Supervisord/Dockerfile
@@ -2,8 +2,9 @@ ARG BUILD_IMAGE="amazon-linux2-base"
 FROM ${BUILD_IMAGE}
 
 LABEL maintainer="CJSE"
-ARG CONFD_VERSION="0.16.0"
-ARG CONFD_CHECKSUM="255d2559f3824dd64df059bdc533fd6b697c070db603c76aaf8d1d5e6b0cc334"
+ARG CONFD_VERSION="0.17.0"
+ARG CONFD_CHECKSUM="d6215d210c93bfac31d956acb171469f48038dd0f1dbac93722cea884d782aa5"
+ARG CONFD_PLATFORM="amd64"
 
 WORKDIR /
 
@@ -27,7 +28,7 @@ RUN mkdir -p /certs && \
     -config /tmp/openssl.cnf \
     -extensions 'v3_req' && \
   rm -rf /tmp/openssl.cnf && \
-  wget -O /bin/confd https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 -nv && \
+  wget -O /bin/confd https://github.com/iwilltry42/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${CONFD_PLATFORM} -nv && \
   echo "${CONFD_CHECKSUM}  /bin/confd" | sha256sum -c && \
   chmod +x /bin/confd && \
   mkdir -p /etc/confd/conf.d && \

--- a/Nginx_Supervisord/Makefile
+++ b/Nginx_Supervisord/Makefile
@@ -1,16 +1,5 @@
 SHELL := /bin/bash # Use bash syntax
 .PHONY: build
 
-image = nginx-supervisord
-
 build:
-	set -e; \
-	docker build --platform linux/amd64 -t "$(image)" . ;\
-	if [[ "${SKIP_GOSS}x" == "truex" ]]; then \
-  		echo "Skipping dgoss tests"; \
-	else \
-		GOSS_SLEEP=15 dgoss run -e \
-		CJSE_NGINX_USERSERVICE_DOMAIN="localhost/elb-status" \
-		-e CJSE_NGINX_APP_DOMAIN="localhost/elb-status" \
-		$(image); \
-	fi
+	bash build.sh

--- a/Nginx_Supervisord/build.sh
+++ b/Nginx_Supervisord/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+IMAGE="nginx-supervisord"
+
+if [ "${PLATFORM}x" = "arm64x" ]; then
+  docker build --platform linux/${PLATFORM} --build-arg BUILD_IMAGE=amazon-linux2-base:arm --build-arg CONFD_CHECKSUM=abd4b6a96b8af12a01e6c3063defec2655d5b817a74d43fb706c9ca8f814dd2e -t "${IMAGE}:arm" . 
+else
+  docker build -t $IMAGE . 
+fi
+
+if [[ "${SKIP_GOSS}x" == "truex" ]]; then \
+    echo "Skipping dgoss tests"; \
+else \
+  GOSS_SLEEP=15 dgoss run -e \
+  CJSE_NGINX_USERSERVICE_DOMAIN="localhost/elb-status" \
+  -e CJSE_NGINX_APP_DOMAIN="localhost/elb-status" \
+  $IMAGE; \
+fi

--- a/NodeJS/Makefile
+++ b/NodeJS/Makefile
@@ -1,13 +1,5 @@
 SHELL := /bin/bash # Use bash syntax
 .PHONY: build
 
-image = nodejs
-
 build:
-	set -e; \
-	docker build --platform linux/amd64 -t "$(image)" . ;\
-	if [[ "${SKIP_GOSS}x" == "truex" ]]; then \
-  		echo "Skipping dgoss tests"; \
-	else \
-		GOSS_SLEEP=15 dgoss run $(image); \
-	fi
+	bash build.sh

--- a/NodeJS/build.sh
+++ b/NodeJS/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+IMAGE="nodejs"
+
+if [ "${PLATFORM}x" = "arm64x" ]; then
+  docker build --platform linux/${PLATFORM} --build-arg BUILD_IMAGE=amazon-linux2-base:arm --build-arg ARCH=arm64 -t "${IMAGE}:arm" . 
+else
+  docker build -t $IMAGE . 
+fi
+
+if [[ "${SKIP_GOSS}x" == "truex" ]]; then
+    echo "Skipping dgoss tests"
+else
+  GOSS_SLEEP=15 dgoss run $IMAGE
+fi

--- a/Openjdk_Jre11_Slim/Dockerfile
+++ b/Openjdk_Jre11_Slim/Dockerfile
@@ -1,5 +1,7 @@
 ARG BUILD_IMAGE="amazon-linux2-base"
+
 FROM ${BUILD_IMAGE}
+ARG JAVA_URL="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.16%2B8/OpenJDK11U-jre_x64_linux_11.0.16_8.tar.gz"
 
 LABEL maintainer="CJSE"
 LABEL source="https://github.com/docker-library/openjdk/blob/master/11/jre/slim-buster/Dockerfile"
@@ -23,9 +25,8 @@ ENV JAVA_VERSION 11.0.16
 
 # hadolint ignore=SC2016
 RUN set -euvx && \
-	downloadUrl='https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.16%2B8/OpenJDK11U-jre_x64_linux_11.0.16_8.tar.gz' && \
-	wget --progress=dot:giga -O openjdk.tgz "$downloadUrl" && \
-	wget --progress=dot:giga -O openjdk.tgz.asc "$downloadUrl.sign" && \
+	wget --progress=dot:giga -O openjdk.tgz ${JAVA_URL} && \
+	wget --progress=dot:giga -O openjdk.tgz.asc "${JAVA_URL}.sign" && \
 	export GNUPGHOME="$(mktemp -d)" && \
 	gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys EAC843EBD3EFDB98CC772FADA5CD6035332FA671 && \
 	gpg --batch --keyserver hkp://keyserver.ubuntu.com --keyserver-options no-self-sigs-only --recv-keys CA5F11C6CE22644D42C6AC4492EF8D39DC13168F && \

--- a/Openjdk_Jre11_Slim/Makefile
+++ b/Openjdk_Jre11_Slim/Makefile
@@ -1,13 +1,5 @@
 SHELL := /bin/bash # Use bash syntax
 .PHONY: build
 
-image = openjdk-jre11-slim
-
 build:
-	set -e; \
-	docker build --platform linux/amd64 -t "$(image)" . ;\
-	if [[ "${SKIP_GOSS}x" == "truex" ]]; then \
-	  	echo "Skipping dgoss tests"; \
-	else \
-		GOSS_SLEEP=15 dgoss run $(image); \
-	fi
+	bash build.sh

--- a/Openjdk_Jre11_Slim/build.sh
+++ b/Openjdk_Jre11_Slim/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+IMAGE="openjdk-jre11-slim"
+
+if [ "${PLATFORM}x" = "arm64x" ]; then
+  docker build --platform linux/${PLATFORM} --build-arg BUILD_IMAGE=amazon-linux2-base:arm --build-arg JAVA_URL=https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.16%2B8/OpenJDK11U-jre_aarch64_linux_11.0.16_8.tar.gz -t "${IMAGE}:arm" . 
+else
+  docker build -t $IMAGE . 
+fi
+
+if [[ "${SKIP_GOSS}x" == "truex" ]]; then
+  echo "Skipping dgoss tests"
+else
+  GOSS_SLEEP=15 dgoss run $IMAGE
+fi

--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ You can skip the goss/dgoss requirement by setting the environment variable `SKI
 
 ### Buildkit
 Buildkit is an option in Docker Desktop. If you're getting errors building Docker images, you might need to change to `"buildkit": false` in Docker Desktop > Options > Docker Engine.
+
+### Building on an ARM-based Mac
+You can build the images used to run the stack components for an ARM Mac by setting the environment variable `PLATFORM=arm64`. Note: this does not apply to the monitoring infrastructure docker images at this point since they generally don't need running locally.


### PR DESCRIPTION
You can build the images used to run the stack components for an ARM Mac by setting the environment variable `PLATFORM=arm64`. Note: this does not apply to the monitoring infrastructure docker images at this point since they generally don't need running locally.

Also note: this is optional rather than automatic because you still need to build `amd64` images for beanconnect and pnc emulator