### PR TITLE
Fix trivy issue with conductor

### DIFF
--- a/scripts/.trivyignore
+++ b/scripts/.trivyignore
@@ -8,3 +8,7 @@ CVE-2022-34169
 
 # Vulnerability in confd for HashiCorp Vault which we don't use, so is not applicable
 CVE-2020-16250
+
+# Vulnerability in Conductor for Spring Framework
+# Spring Framework through 5.3.16 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data. Depending on how the library is implemented within a product, this issue may or not occur, and authentication may be required
+CVE-2016-1000027

--- a/scripts/.trivyignore
+++ b/scripts/.trivyignore
@@ -11,4 +11,5 @@ CVE-2020-16250
 
 # Vulnerability in Conductor for Spring Framework
 # Spring Framework through 5.3.16 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data. Depending on how the library is implemented within a product, this issue may or not occur, and authentication may be required
+# Ignored the vulnerability because we run Conductor in a private network, and the web interface and API are protected by basic authentication via Nginx
 CVE-2016-1000027

--- a/scripts/run_trivy_tests.sh
+++ b/scripts/run_trivy_tests.sh
@@ -34,4 +34,5 @@ TRIVY_CACHE_DIR=trivy trivy image \
     --exit-code 1 \
     --ignorefile ../scripts/.trivyignore \
     --skip-update \
+    --timeout 180m \
   ${DOCKER_IMAGE}


### PR DESCRIPTION
This PR:

- Ignores `CVE-2016-1000027` vulnerability in Conductor image for Sprint Framework
- Increases Trivy timeout to 180 minutes