### PR TITLE
Enable the region to be set for the endpoint and allow yellow elasticsearch clusters

### DIFF
--- a/Conductor/confd/templates/config.properties.tpl
+++ b/Conductor/confd/templates/config.properties.tpl
@@ -26,6 +26,7 @@ conductor.elasticsearch.version={{ getv "/cjse/conductor/elasticsearch/version" 
 conductor.elasticsearch.url={{ getv "/cjse/conductor/elasticsearch/url" "http://es:9200" }}
 conductor.elasticsearch.username={{ getv "/cjse/conductor/elasticsearch/username" "bichard" }}
 conductor.elasticsearch.password={{ getv "/cjse/conductor/elasticsearch/password" "password" }}
+conductor.elasticsearch.clusterHealthColor={{ getv "/cjse/conductor/elasticsearch/healthcolor" "yellow" }}
 
 # Name of the elasticsearch cluster
 conductor.elasticsearch.indexName={{ getv "/cjse/conductor/elasticsearch/indexname" "conductor" }}

--- a/Conductor/patches/sqs-endpoint-1.patch
+++ b/Conductor/patches/sqs-endpoint-1.patch
@@ -1,5 +1,5 @@
 --- Conductor/conductor/awssqs-event-queue/src/main/java/com/netflix/conductor/sqs/config/SQSEventQueueConfiguration.java	2023-01-26 21:44:09
-+++ Conductor/conductor/awssqs-event-queue/src/main/java/com/netflix/conductor/sqs/config/SQSEventQueueConfiguration-updated.java	2023-02-09 11:32:21
++++ Conductor/conductor/awssqs-event-queue/src/main/java/com/netflix/conductor/sqs/config/SQSEventQueueConfiguration-updated.java	2023-02-10 10:13:36
 @@ -16,6 +16,9 @@
  import java.util.Map;
  
@@ -19,7 +19,7 @@
  import com.amazonaws.services.sqs.AmazonSQS;
  import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
  import rx.Scheduler;
-@@ -38,10 +43,26 @@
+@@ -38,10 +43,27 @@
  @ConditionalOnProperty(name = "conductor.event-queues.sqs.enabled", havingValue = "true")
  public class SQSEventQueueConfiguration {
  
@@ -41,7 +41,8 @@
 +        if (!sqsProperties.getEndpoint().isEmpty()) {
 +            LOGGER.info("Setting custom SQS endpoint to {}", sqsProperties.getEndpoint());
 +            builder.withEndpointConfiguration(
-+                    new AwsClientBuilder.EndpointConfiguration(sqsProperties.getEndpoint(), null));
++                    new AwsClientBuilder.EndpointConfiguration(
++                            sqsProperties.getEndpoint(), System.getenv("AWS_REGION")));
 +        }
 +        return builder.build();
      }


### PR DESCRIPTION
When running against localstack we need to set the region

Often when running in Docker the elasticsearch cluster is in yellow state because of low resources. This enables us to configure it.