### PR TITLE
Tweak conductor image startup

### DIFF
--- a/Conductor/build.sh
+++ b/Conductor/build.sh
@@ -2,8 +2,7 @@
 
 set -ex
 
-CONDUCTOR_VERSION=$(cat conductor_version)
-IMAGE="conductor:${CONDUCTOR_VERSION}"
+IMAGE="conductor"
 
 /bin/bash scripts/download_and_patch_conductor.sh
 

--- a/Conductor/conf/supervisord.conf
+++ b/Conductor/conf/supervisord.conf
@@ -36,9 +36,9 @@ startsecs=0
 exitcodes=0
 
 [program:nginx]
-command=/usr/sbin/nginx -g 'daemon off;'
+command=bash -c "sleep 10 && /usr/sbin/nginx -g 'daemon off;'"
 priority=900
-stdout_logfile= /dev/stdout
+stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
@@ -48,7 +48,7 @@ autorestart=true
 [program:conductor]
 command=java -jar -DCONDUCTOR_CONFIG_FILE=/app/config/config.properties /app/libs/conductor-server-boot.jar
 priority=200
-stdout_logfile= /dev/stdout
+stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0


### PR DESCRIPTION
This PR:
- Tags built conductor images as `latest`, rather than `v3.13.3` etc
- Delays starting Nginx inside supervisord for 10 seconds, to give Conductor a chance to boot first