### PR TITLE
Fix logstash elasticsearch on local

### DIFF
--- a/Logstash/Makefile
+++ b/Logstash/Makefile
@@ -13,3 +13,16 @@ build:
 		-e CJSE_LOGSTASH_LOCAL=true \
 		$(image); \
 	fi
+
+run-logstash:
+	npx -y concurrently -c --kill-others -n Watcher,Logstash "./scripts/watch-templates.sh" "docker compose up logstash"
+
+run-elasticsearch:
+	docker compose up elasticsearch
+
+run:
+	npx -y concurrently -c --kill-others -n Watcher,Logstash/ES "./scripts/watch-templates.sh" "docker compose up"
+
+stop:
+	docker compose down
+

--- a/Logstash/README.md
+++ b/Logstash/README.md
@@ -18,7 +18,9 @@ data from.
 
 run:
 
-`make build`
+```sh
+make build
+```
 
 ### Running against a local ES to develop/debug grok filters
 
@@ -27,11 +29,12 @@ goss.env
 
 run: 
 
-- `docker-compose up`
+```sh
+make run
+```
 
-bootstrapping the first time will take about 5 minutes. 
-You can then docker exec into the `logstash` container and modify the relevant .conf 
-file. Logstash will reload automatically if they have changed.
+Bootstrapping the first time will take about 5 minutes.
+You can now make changes to the template files. Logstash will be updated and reloaded automatically as you make changes.
 
 You can then connect to Kibana on http://localhost:5601, go to the `global` tenant if prompted,
 then click on discover and it should take you to the index patterns. If there is no data, give it a few minutes to start
@@ -52,7 +55,9 @@ Update the CJSE_ENVIRONMENT variable to point to the correct environment, then f
 
 run:
 
-- `docker-compose up logstash`
+```sh
+make run-logstash
+```
 
 #### Developing grok filters
 

--- a/Logstash/docker-compose.yml
+++ b/Logstash/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     restart: "unless-stopped"
 
   logstash:
-    image: logstash:7.17.7
+    image: logstash
     container_name: logstash
     env_file:
       - goss.env

--- a/Logstash/scripts/watch-templates.sh
+++ b/Logstash/scripts/watch-templates.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+export TERM="xterm"
+
+if [ "$(uname)" == "Darwin" ]; then
+  # Mac OSX
+  WATCH_COMMAND="ls -R -l -T ./confd | md5"
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  WATCH_COMMAND="ls --all -l --recursive --full-time ./confd | sha256sum"
+fi
+
+trap "echo Exited!; exit;" SIGINT SIGTERM
+echo "Watching template files changes..."
+while [[ 1=1 ]]
+do
+  watch -t --chgexit -n 1 "${WATCH_COMMAND}" 1> /dev/null && \
+    echo "Updating logstash file changes..." && \
+    docker exec -it $(docker compose ps logstash -q) rm -rf /etc/logstash-dev/conf.d 2> /dev/null && \
+    docker cp ./confd $(docker compose ps logstash -q):/etc/logstash-dev && \
+    docker exec -it $(docker compose ps logstash -q) /bin/confd -onetime -backend env -confdir /etc/logstash-dev/confd
+
+  echo "Logstash files updated."
+  sleep 1
+done


### PR DESCRIPTION
This PR adds a script to detect Logstash template files changes and update them in the `logstash` container. This helps with debugging grok filters locally.