### PR TITLE
Invalid csrf redirect

### DIFF
--- a/Nginx_Auth_Proxy/confd/templates/bichard.http.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/bichard.http.conf.tpl
@@ -30,10 +30,10 @@ location @error403 {
     proxy_ssl_server_name on;
     proxy_ssl_verify_depth 2;
     absolute_redirect off;
-    if ($upstream_http_x_status_text = "Invalid CSRF-token") {
+    if ($upstream_http_x_status_message = "Invalid CSRF-token") {
         return 302 $request_uri;
     }
-    if ($upstream_http_x_status_text != "Invalid CSRF-token") {
+    if ($upstream_http_x_status_message != "Invalid CSRF-token") {
         rewrite /(.*) /users/403;
     }
 }

--- a/Nginx_Auth_Proxy/confd/templates/bichard.http.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/bichard.http.conf.tpl
@@ -22,11 +22,26 @@ location @error401 {
     return 302 /users/login?redirect=$request_uri;
 }
 
-# Display error page for 403, 404 and 500 errors
-error_page 403 =403 /403;
+# Redirect unauthorised to 403 error page and request with invalid CSRF token to the same page
+error_page 403 = @error403;
+location @error403 {
+    limit_except      GET POST PUT DELETE { deny all; }
+    include /etc/includes/headers.conf;
+    proxy_ssl_server_name on;
+    proxy_ssl_verify_depth 2;
+    absolute_redirect off;
+    if ($upstream_http_x_status_text = "Invalid CSRF-token") {
+        return 302 $request_uri;
+    }
+    if ($upstream_http_x_status_text != "Invalid CSRF-token") {
+        rewrite /(.*) /users/403;
+    }
+}
+
+# Display error page for 404 and 500 errors
 error_page 404 =404 /404;
 error_page 500 =500 /500;
-location ~ ^/(403|404|500)$ {
+location ~ ^/(404|500)$ {
     proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
     limit_except      GET POST PUT { deny all; }
     include /etc/includes/headers.conf;
@@ -139,7 +154,7 @@ location /help {
 }
 
 # Allow access to user-service login flow (and necessary assets) without authentication
-location ~ ^/users/(login|fonts|images|_next/static|403|404|500|faq)(.*)$ {
+location ~ ^/users/(login|fonts|images|_next/static|faq)(.*)$ {
     limit_except GET POST PUT { deny all; }
     include /etc/includes/headers.conf;
 
@@ -149,6 +164,21 @@ location ~ ^/users/(login|fonts|images|_next/static|403|404|500|faq)(.*)$ {
     proxy_cookie_flags ~ httponly samesite=strict;
     proxy_ssl_server_name on;
     proxy_ssl_verify_depth 2;
+    proxy_intercept_errors on;
+}
+
+# Allow access to error pages without authentication
+location ~ ^/users/(404|403|500)(.*)$ {
+    limit_except GET POST PUT { deny all; }
+    include /etc/includes/headers.conf;
+
+    proxy_pass        https://$userservice;
+    proxy_set_header X-Origin https://$host;
+    proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
+    proxy_cookie_flags ~ httponly secure samesite=strict;
+    proxy_ssl_server_name on;
+    proxy_ssl_verify_depth 2;
+    proxy_intercept_errors off;
 }
 
 # Allow access to bichard-ui health check, connectivity and static endpoints without authentication

--- a/Nginx_Auth_Proxy/confd/templates/bichard.https.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/bichard.https.conf.tpl
@@ -32,10 +32,10 @@ location @error403 {
     proxy_ssl_server_name on;
     proxy_ssl_verify_depth 2;
     absolute_redirect off;
-    if ($upstream_http_x_status_text = "Invalid CSRF-token") {
+    if ($upstream_http_x_status_message = "Invalid CSRF-token") {
         return 302 $request_uri;
     }
-    if ($upstream_http_x_status_text != "Invalid CSRF-token") {
+    if ($upstream_http_x_status_message != "Invalid CSRF-token") {
         rewrite /(.*) /users/403;
     }
 }

--- a/Nginx_Auth_Proxy/confd/templates/bichard.https.conf.tpl
+++ b/Nginx_Auth_Proxy/confd/templates/bichard.https.conf.tpl
@@ -13,7 +13,6 @@ set $userservice "{{ getv "/cjse/nginx/userservice/domain" }}";
 set $ui "{{ getv "/cjse/nginx/ui/domain" }}";
 set $staticservice "{{ getv "/cjse/nginx/staticservice/domain" }}";
 
-
 # Redirect any unauthenticated users to the login page
 error_page 401 = @error401;
 location @error401 {
@@ -25,11 +24,26 @@ location @error401 {
     return 302 /users/login?redirect=$request_uri;
 }
 
-# Display error page for 403, 404 and 500 errors
-error_page 403 =403 /403;
+# Redirect unauthorised to 403 error page and request with invalid CSRF token to the same page
+error_page 403 = @error403;
+location @error403 {
+    limit_except      GET POST PUT DELETE { deny all; }
+    include /etc/includes/headers.conf;
+    proxy_ssl_server_name on;
+    proxy_ssl_verify_depth 2;
+    absolute_redirect off;
+    if ($upstream_http_x_status_text = "Invalid CSRF-token") {
+        return 302 $request_uri;
+    }
+    if ($upstream_http_x_status_text != "Invalid CSRF-token") {
+        rewrite /(.*) /users/403;
+    }
+}
+
+# Display error page for 404 and 500 errors
 error_page 404 =404 /404;
 error_page 500 =500 /500;
-location ~ ^/(403|404|500)$ {
+location ~ ^/(404|500)$ {
     proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
     limit_except      GET POST PUT { deny all; }
     add_header  Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
@@ -93,7 +107,7 @@ location /bichard {
     proxy_pass        https://$ui;
     proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
     proxy_set_header Host $http_host;
-    
+
     # New Bichard UI sets it's own CSP before it reaches nginx
     proxy_pass_header Content-Security-Policy;
 
@@ -150,7 +164,7 @@ location /help {
 }
 
 # Allow access to user-service login flow (and necessary assets) without authentication
-location ~ ^/users/(login|fonts|images|_next/static|403|404|500|faq)(.*)$ {
+location ~ ^/users/(login|fonts|images|_next/static|faq)(.*)$ {
     limit_except GET POST PUT { deny all; }
     add_header  Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     include /etc/includes/headers.conf;
@@ -161,6 +175,22 @@ location ~ ^/users/(login|fonts|images|_next/static|403|404|500|faq)(.*)$ {
     proxy_cookie_flags ~ httponly secure samesite=strict;
     proxy_ssl_server_name on;
     proxy_ssl_verify_depth 2;
+    proxy_intercept_errors on;
+}
+
+# Allow access to error pages without authentication
+location ~ ^/users/(404|403|500)(.*)$ {
+    limit_except GET POST PUT { deny all; }
+    add_header  Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    include /etc/includes/headers.conf;
+
+    proxy_pass        https://$userservice;
+    proxy_set_header X-Origin https://$host;
+    proxy_ssl_verify  {{ getv "/cjse/nginx/proxysslverify" "on" }};
+    proxy_cookie_flags ~ httponly secure samesite=strict;
+    proxy_ssl_server_name on;
+    proxy_ssl_verify_depth 2;
+    proxy_intercept_errors off;
 }
 
 # Allow access to bichard-ui health check, connectivity and static endpoints without authentication

--- a/Nginx_Supervisord/Dockerfile
+++ b/Nginx_Supervisord/Dockerfile
@@ -12,7 +12,7 @@ COPY files/openssl.cnf /tmp/openssl.cnf
 
 RUN mkdir -p /certs && \
     mkdir -p /var/log/supervisor && \
-    yum update && \
+    yum update -y && \
     yum install -y yum-utils
 
 COPY files/nginx.repo /etc/yum.repos.d/nginx.repo


### PR DESCRIPTION
This PR updates Nginx Auth Proxy for 403 errors to:
- read the `X-Status-Message` HTTP header and check if the 403 error is because of an invalid CSRF token
- if yes, it redirects to the same page. This will reload the page with a new CSRF token.
- if no, shows access denied page