### PR TITLE
Bicaws-3025: Add amazon linux 2023 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     machine:
       image: ubuntu-2204:2023.07.2
-      docker_layer_caching: true
+      # docker_layer_caching: true
     steps:
       - checkout
       - run: sudo bash scripts/install_goss.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     machine:
       image: ubuntu-2204:2023.07.2
-      # docker_layer_caching: true
+      docker_layer_caching: true
     steps:
       - checkout
       - run: sudo bash scripts/install_goss.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   test:
     machine:
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2204:2023.07.2
       docker_layer_caching: true
     steps:
       - checkout

--- a/Amazon_Linux_2023_Base/Dockerfile
+++ b/Amazon_Linux_2023_Base/Dockerfile
@@ -3,10 +3,10 @@ ARG BUILD_IMAGE="amazonlinux:2023"
 FROM ${BUILD_IMAGE}
 
 LABEL maintainer="CJSE"
-ARG DNF_PACKAGES="pip gzip tar unzip openssl shadow-utils xz wget gnupg"
+ARG DNF_PACKAGES="pip gzip tar unzip openssl shadow-utils xz wget gnupg dirmngr"
 
 RUN dnf update -y &&\
-    dnf install -y ${DNF_PACKAGES}
+    dnf install -y ${DNF_PACKAGES} --allowerasing
 
 # https://github.com/aws/aws-cli/issues/8036
 RUN pip install wheel &&\

--- a/Amazon_Linux_2023_Base/Dockerfile
+++ b/Amazon_Linux_2023_Base/Dockerfile
@@ -3,14 +3,14 @@ ARG BUILD_IMAGE="amazonlinux:2023"
 FROM ${BUILD_IMAGE}
 
 LABEL maintainer="CJSE"
-ARG YUM_PACKAGES="python-pip gzip tar unzip openssl shadow-utils xz wget gnupg"
+ARG DNF_PACKAGES="python-pip gzip tar unzip openssl shadow-utils xz wget gnupg"
 ARG PIP_PACKAGES="awscli"
 
-RUN yum update -y && \
-    yum install -y ${YUM_PACKAGES} && \
+RUN dnf update -y && \
+    dnf install -y ${DNF_PACKAGES} && \
     pip install --no-cache-dir ${PIP_PACKAGES} && \
     rm -rf /var/log/* && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 CMD ["tail", "-f", "/dev/null"]

--- a/Amazon_Linux_2023_Base/Dockerfile
+++ b/Amazon_Linux_2023_Base/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_IMAGE="amazonlinux:2023"
 FROM ${BUILD_IMAGE}
 
 LABEL maintainer="CJSE"
-ARG DNF_PACKAGES="python-pip gzip tar unzip openssl shadow-utils xz wget gnupg"
+ARG DNF_PACKAGES="python python2-pip gzip tar unzip openssl shadow-utils xz wget gnupg"
 ARG PIP_PACKAGES="awscli"
 
 RUN dnf update -y && \

--- a/Amazon_Linux_2023_Base/Dockerfile
+++ b/Amazon_Linux_2023_Base/Dockerfile
@@ -3,14 +3,17 @@ ARG BUILD_IMAGE="amazonlinux:2023"
 FROM ${BUILD_IMAGE}
 
 LABEL maintainer="CJSE"
-ARG DNF_PACKAGES="python python2-pip gzip tar unzip openssl shadow-utils xz wget gnupg"
-ARG PIP_PACKAGES="awscli"
+ARG DNF_PACKAGES="pip gzip tar unzip openssl shadow-utils xz wget gnupg"
 
-RUN dnf update -y && \
-    dnf install -y ${DNF_PACKAGES} && \
-    pip install --no-cache-dir ${PIP_PACKAGES} && \
-    rm -rf /var/log/* && \
-    dnf clean all && \
+RUN dnf update -y &&\
+    dnf install -y ${DNF_PACKAGES}
+
+# https://github.com/aws/aws-cli/issues/8036
+RUN pip install wheel &&\
+    pip install "Cython<3.0" "pyyaml<6" --no-build-isolation 
+
+RUN rm -rf /var/log/* &&\
+    dnf clean all &&\
     rm -rf /var/cache/dnf
 
 CMD ["tail", "-f", "/dev/null"]

--- a/Amazon_Linux_2023_Base/Dockerfile
+++ b/Amazon_Linux_2023_Base/Dockerfile
@@ -1,0 +1,16 @@
+ARG BUILD_IMAGE="amazonlinux:2023"
+
+FROM ${BUILD_IMAGE}
+
+LABEL maintainer="CJSE"
+ARG YUM_PACKAGES="python-pip gzip tar unzip openssl shadow-utils xz wget gnupg"
+ARG PIP_PACKAGES="awscli"
+
+RUN yum update -y && \
+    yum install -y ${YUM_PACKAGES} && \
+    pip install --no-cache-dir ${PIP_PACKAGES} && \
+    rm -rf /var/log/* && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+CMD ["tail", "-f", "/dev/null"]

--- a/Amazon_Linux_2023_Base/Makefile
+++ b/Amazon_Linux_2023_Base/Makefile
@@ -1,0 +1,5 @@
+SHELL := /bin/bash # Use bash syntax
+.PHONY: build
+
+build:
+	bash build.sh

--- a/Amazon_Linux_2023_Base/build.sh
+++ b/Amazon_Linux_2023_Base/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+IMAGE="amazon-linux2023-base"
+
+docker build -t "${IMAGE}" . 
+
+if [ "$SKIP_GOSS" = "true" ]; then
+  echo "Skipping dgoss tests"
+else
+  GOSS_SLEEP=15 dgoss run $IMAGE
+fi

--- a/Amazon_Linux_2023_Base/buildspec.yml
+++ b/Amazon_Linux_2023_Base/buildspec.yml
@@ -1,0 +1,11 @@
+---
+
+version: 0.2
+phases:
+  build:
+    commands:
+      - set -ev
+      - cd ./Amazon_Linux_2023_Base
+      - /bin/bash ./scripts/build_docker.sh
+
+...

--- a/Amazon_Linux_2023_Base/goss.yaml
+++ b/Amazon_Linux_2023_Base/goss.yaml
@@ -10,8 +10,6 @@ file:
 package:
   deltarpm:
     installed: true
-  epel-release:
-    installed: true
   python:
     installed: true
   python2-pip:
@@ -19,8 +17,8 @@ package:
 user:
   nobody:
     exists: true
-    uid: 99
-    gid: 99
+    uid: 65534
+    gid: 65534
     groups:
     - nobody
     home: /

--- a/Amazon_Linux_2023_Base/goss.yaml
+++ b/Amazon_Linux_2023_Base/goss.yaml
@@ -1,0 +1,27 @@
+file:
+  /etc/passwd:
+    exists: true
+    mode: "0644"
+    size: 513
+    owner: root
+    group: root
+    filetype: file
+    contains: []
+package:
+  deltarpm:
+    installed: true
+  epel-release:
+    installed: true
+  python:
+    installed: true
+  python2-pip:
+    installed: true
+user:
+  nobody:
+    exists: true
+    uid: 99
+    gid: 99
+    groups:
+    - nobody
+    home: /
+    shell: /sbin/nologin

--- a/Amazon_Linux_2023_Base/goss.yaml
+++ b/Amazon_Linux_2023_Base/goss.yaml
@@ -2,7 +2,7 @@ file:
   /etc/passwd:
     exists: true
     mode: "0644"
-    size: 513
+    size: 533
     owner: root
     group: root
     filetype: file

--- a/Amazon_Linux_2023_Base/goss.yaml
+++ b/Amazon_Linux_2023_Base/goss.yaml
@@ -2,7 +2,7 @@ file:
   /etc/passwd:
     exists: true
     mode: "0644"
-    size: 533
+    size: 839
     owner: root
     group: root
     filetype: file

--- a/Amazon_Linux_2023_Base/goss.yaml
+++ b/Amazon_Linux_2023_Base/goss.yaml
@@ -7,13 +7,6 @@ file:
     group: root
     filetype: file
     contains: []
-package:
-  deltarpm:
-    installed: true
-  python:
-    installed: true
-  python2-pip:
-    installed: true
 user:
   nobody:
     exists: true

--- a/Amazon_Linux_2023_Base/scripts/build_docker.sh
+++ b/Amazon_Linux_2023_Base/scripts/build_docker.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+export readonly REPOSITORY_NAME="amazon-linux2023-base"
+export readonly SOURCE_REPOSITORY_NAME="amazon-linux-2023"
+
+/bin/bash ../scripts/build_and_push_image.sh
+
+aws codebuild start-build --project-name "build-openjdk-jre11-slim-docker" \
+  --environment-variables-override name=DOCKER_IMAGE_HASH,value="${DOCKER_IMAGE_PREFIX}@${SHA_HASH}",type=PLAINTEXT
+
+aws codebuild start-build --project-name "build-nodejs-16-docker" \
+  --environment-variables-override name=DOCKER_IMAGE_HASH,value="${DOCKER_IMAGE_PREFIX}@${SHA_HASH}",type=PLAINTEXT
+
+aws codebuild start-build --project-name "build-logstash-docker" \
+  --environment-variables-override name=DOCKER_IMAGE_HASH,value="${DOCKER_IMAGE_PREFIX}@${SHA_HASH}",type=PLAINTEXT
+
+aws codebuild start-build --project-name "build-grafana-ssl-docker"
+
+aws codebuild start-build --project-name "build-grafana-codebuild-ssl-docker"
+
+aws codebuild start-build --project-name "build-nginx-supervisord-docker"
+
+aws codebuild start-build --project-name "build-postfix-docker"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BASE_CONTAINERS:= Amazon_Linux_Base Openjdk_Jre11_Slim NodeJS Postfix Codebuild_Base
+BASE_CONTAINERS:= Amazon_Linux_Base Openjdk_Jre11_Slim NodeJS Postfix Codebuild_Base Amazon_Linux_2023_Base
 NGINX_CONTAINERS:= Nginx_NodeJS_Supervisord Nginx_Supervisord Nginx_Auth_Proxy Nginx_Java_Supervisord S3_Web_Proxy Scanning_Results_Portal Conductor
 MONITORING_CONTAINERS:= Grafana Grafana_Codebuild Prometheus Prometheus_Cloudwatch_Exporter Logstash Prometheus_BlackBox_Exporter
 

--- a/NodeJS/Dockerfile
+++ b/NodeJS/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE="amazon-linux2-base"
+ARG BUILD_IMAGE="amazon-linux2023-base"
 FROM ${BUILD_IMAGE}
 
 LABEL maintainer="CJSE"

--- a/NodeJS/Dockerfile
+++ b/NodeJS/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE="amazon-linux2023-base"
+ARG BUILD_IMAGE="amazon-linux2-base"
 FROM ${BUILD_IMAGE}
 
 LABEL maintainer="CJSE"


### PR DESCRIPTION
This commit adds a new infrastructure image based on `amazonlinux:2023`. Note that several packages are no longer supported, such as python 2 and epel.