### PR TITLE
Fix awscli v1 dependency installation for legacy AMI base

### DIFF
--- a/Amazon_Linux_Base/Dockerfile
+++ b/Amazon_Linux_Base/Dockerfile
@@ -6,13 +6,18 @@ LABEL maintainer="CJSE"
 ARG YUM_PACKAGES="python-pip gzip tar unzip openssl shadow-utils xz wget gnupg"
 ARG PIP_PACKAGES="awscli"
 
-RUN yum update -y && \
-    amazon-linux-extras install -y epel && \
-    yum install -y deltarpm && \
-    yum install -y ${YUM_PACKAGES} && \
-    pip install --no-cache-dir ${PIP_PACKAGES} && \
-    rm -rf /var/log/* && \
-    yum clean all && \
+RUN yum update -y &&\
+    amazon-linux-extras install -y epel &&\
+    yum install -y deltarpm &&\
+    yum install -y ${YUM_PACKAGES}
+
+# https://github.com/aws/aws-cli/issues/8036
+RUN pip install wheel &&\
+    pip install "Cython<3.0" "pyyaml<6" --no-build-isolation &&\
+    pip install --no-cache-dir ${PIP_PACKAGES}
+
+RUN rm -rf /var/log/* &&\
+    yum clean all &&\
     rm -rf /var/cache/yum
 
 CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
`pip install awscli` has recently developed some issues around dependency versions. Official advice is to upgrade to awscli v2 - new AMI base should definitely do that, but this fixes the existing one for now.

https://github.com/aws/aws-cli/issues/8036