### PR TITLE
BICAWS-3040 Update conductor dashboard

### DIFF
--- a/Grafana/confd/templates/conductor-dashboard.json.tpl
+++ b/Grafana/confd/templates/conductor-dashboard.json.tpl
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 34,
+  "id": 199,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -36,14 +36,16 @@
         "x": 0,
         "y": 0
       },
-      "id": 4,
+      "id": 22,
       "panels": [],
-      "title": "General",
+      "title": "Workflow and Task Metrics",
       "type": "row"
     },
     {
-      "datasource": null,
-      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -84,6 +86,10 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           }
@@ -91,12 +97,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 24,
+        "h": 8,
+        "w": 18,
         "x": 0,
         "y": 1
       },
-      "id": 2,
+      "id": 14,
       "options": {
         "legend": {
           "calcs": [],
@@ -108,156 +114,28 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.5.15",
       "targets": [
         {
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "task_queue_depth{}",
-          "instant": false,
-          "legendFormat": "{{"{{"}}taskType{{"}}"}}",
+          "expr": "task_queue_depth",
+          "legendFormat": "{{taskType}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Task queue depth",
+      "title": "Task Queue Length",
       "type": "timeseries"
     },
     {
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
       },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 10
-      },
-      "id": 14,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.5.15",
-      "targets": [
-        {
-          "datasource": null,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "event_queue_messages_processed_total{}",
-          "format": "time_series",
-          "instant": false,
-          "legendFormat": "{{"{{"}}queueName{{"}}"}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "SQS messages fetched",
-      "type": "stat"
-    },
-    {
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 10
-      },
-      "id": 15,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.5.15",
-      "targets": [
-        {
-          "datasource": null,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "event_queue_messages_handled_total{}",
-          "format": "time_series",
-          "instant": false,
-          "legendFormat": "{{"{{"}}queueName{{"}}"}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Total SQS messages handled",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 17
-      },
-      "id": 12,
-      "panels": [],
-      "title": "Others",
-      "type": "row"
-    },
-    {
-      "datasource": null,
-      "description": "",
+      "description": "Time spent by a task in queue",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -310,268 +188,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 10,
+        "h": 8,
+        "w": 9,
         "x": 0,
-        "y": 18
-      },
-      "id": 10,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "editorMode": "code",
-          "expr": "task_queue_wait_seconds_max{}",
-          "legendFormat": "{{"{{"}}taskType{{"}}"}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Maximum wait time in the queue by task type",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 10,
-        "x": 10,
-        "y": 18
-      },
-      "id": 8,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "8.5.15",
-      "targets": [
-        {
-          "datasource": null,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "workflow_execution_seconds_max{}",
-          "format": "time_series",
-          "instant": false,
-          "legendFormat": "{{"{{"}}workflowName{{"}}"}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Maximum workflow execution time",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 10,
-        "x": 0,
-        "y": 24
-      },
-      "id": 17,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "editorMode": "builder",
-          "exemplar": false,
-          "expr": "task_execution_seconds_max{includeRetries=\"false\"}",
-          "instant": false,
-          "legendFormat": "{{"{{"}}taskType{{"}}"}}",
-          "range": true,
-          "rawQuery": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Maximum task execution time (Excluding retries)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 10,
-        "x": 10,
-        "y": 24
+        "y": 9
       },
       "id": 18,
       "options": {
@@ -587,23 +207,25 @@
       },
       "targets": [
         {
-          "datasource": null,
-          "editorMode": "builder",
-          "exemplar": false,
-          "expr": "task_execution_seconds_max{includeRetries=\"true\"}",
-          "instant": false,
-          "legendFormat": "{{"{{"}}taskType{{"}}"}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "task_queue_wait_seconds_max",
+          "legendFormat": "{{taskType}}",
           "range": true,
-          "rawQuery": true,
           "refId": "A"
         }
       ],
-      "title": "Maximum task execution time (Including retries)",
+      "title": "Max Wait Time in Queue by Task Type",
       "type": "timeseries"
     },
     {
-      "datasource": null,
-      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -644,6 +266,10 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           }
@@ -651,10 +277,299 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 10,
+        "h": 8,
+        "w": 9,
+        "x": 9,
+        "y": 9
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "workflow_running{}",
+          "legendFormat": "{{workflowName}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "hide": false,
+          "refId": "B"
+        }
+      ],
+      "title": "Number of Running Workflows",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
         "x": 0,
-        "y": 30
+        "y": 17
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "workflow_failure_total",
+          "legendFormat": "{{workflowName}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Number of Workflow Failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 9,
+        "y": 17
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "workflow_execution_seconds_max",
+          "legendFormat": "{{workflowName}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Max Workflow Duration",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 20,
+      "panels": [],
+      "title": "AWS ECS Usage",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 0,
+        "y": 26
       },
       "id": 6,
       "options": {
@@ -668,24 +583,392 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.5.15",
       "targets": [
         {
-          "datasource": null,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "workflow_running{}",
-          "instant": false,
-          "legendFormat": "{{"{{"}}workflowName{{"}}"}}",
+          "expr": "aws_ecs_cpuutilization_maximum{service_name=\"cjse-production-bichard-7-conductor-core-worker\"}",
+          "hide": false,
+          "legendFormat": "{{service_name}} (Max)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "aws_ecs_cpuutilization_average{service_name=\"cjse-production-bichard-7-conductor-core-worker\"}",
+          "interval": "",
+          "legendFormat": "{{service_name}} (Average)",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "aws_ecs_cpuutilization_minimum{service_name=\"cjse-production-bichard-7-conductor-core-worker\"}",
+          "hide": false,
+          "legendFormat": "{{service_name}} (Min)",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Running workflows",
+      "title": "CPU Utilisation: Conductor Worker",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 9,
+        "y": 26
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "aws_ecs_memory_utilization_average{service_name=\"cjse-production-bichard-7-conductor-core-worker\"}",
+          "legendFormat": "{{service_name}} (Average)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "aws_ecs_memory_utilization_maximum{service_name=\"cjse-production-bichard-7-conductor-core-worker\"}",
+          "hide": false,
+          "legendFormat": "{{service_name}} (Max)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "aws_ecs_memory_utilization_minimum{service_name=\"cjse-production-bichard-7-conductor-core-worker\"}",
+          "hide": false,
+          "legendFormat": "{{service_name}} (Min)",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Memory Utilisation: Conductor Worker",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 9,
+        "x": 0,
+        "y": 34
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "aws_ecs_cpuutilization_average{service_name=\"cjse-production-bichard-7-conductor\"}",
+          "hide": false,
+          "legendFormat": "{{service_name}} (Average)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "aws_ecs_cpuutilization_maximum{service_name=\"cjse-production-bichard-7-conductor\"}",
+          "hide": false,
+          "legendFormat": "{{service_name}} (Max)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "aws_ecs_cpuutilization_minimum{service_name=\"cjse-production-bichard-7-conductor\"}",
+          "hide": false,
+          "legendFormat": "{{service_name}} (Min)",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "CPU Utilisation: Conductor Server",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 9,
+        "x": 9,
+        "y": 34
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "aws_ecs_memory_utilization_average{service_name=\"cjse-production-bichard-7-conductor\"}",
+          "hide": false,
+          "legendFormat": "{{service_name}} (Average)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "aws_ecs_memory_utilization_maximum{service_name=\"cjse-production-bichard-7-conductor\"}",
+          "hide": false,
+          "legendFormat": "{{service_name}} (Max)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
+          },
+          "editorMode": "code",
+          "expr": "aws_ecs_memory_utilization_minimum{service_name=\"cjse-production-bichard-7-conductor\"}",
+          "hide": false,
+          "legendFormat": "{{service_name}} (Min)",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Memory Utilisation: Conductor Server",
       "type": "timeseries"
     }
   ],
-  "refresh": "",
+  "refresh": false,
   "schemaVersion": 36,
   "style": "dark",
   "tags": [],
@@ -699,7 +982,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Conductor",
-  "uid": "0R-KoIBVz",
-  "version": 1,
+  "uid": "X8ztTteVk",
+  "version": 8,
   "weekStart": ""
 }

--- a/Grafana/confd/templates/conductor-dashboard.json.tpl
+++ b/Grafana/confd/templates/conductor-dashboard.json.tpl
@@ -42,10 +42,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
-      },
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -131,10 +128,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
-      },
+      "datasource": null,
       "description": "Time spent by a task in queue",
       "fieldConfig": {
         "defaults": {
@@ -222,10 +216,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
-      },
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -319,10 +310,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
-      },
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -408,10 +396,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
-      },
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -511,10 +496,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
-      },
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -625,10 +607,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
-      },
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -738,10 +717,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
-      },
+      "datasource": null,
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -853,10 +829,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "e6c0c6c2d40d11ebb8bc0242ac130003"
-      },
+      "datasource": null,
       "description": "",
       "fieldConfig": {
         "defaults": {


### PR DESCRIPTION
Update current conductor dashboard with more useful info. 

Added:
- ECS CPU & memory utilisation for worker and server
- Conductor specific metrics: task queue length, queue wait time, running workflows, workflow failures, workflow duration

TODO:
Separate PR for updating Prometheus CloudWatch Exporter Image and implement AWS SQS queue data onto this dashboard. 

![image](https://github.com/ministryofjustice/bichard7-next-infrastructure-docker-images/assets/105787366/4d37f057-a1c3-4166-b95e-7ca3ea62e0a3)
![Uploading image.png…]()
