### PR TITLE
Update ca-certificates package in Amazon Linux 2023 base image

### DIFF
--- a/Amazon_Linux_2023_Base/Dockerfile
+++ b/Amazon_Linux_2023_Base/Dockerfile
@@ -8,6 +8,8 @@ ARG DNF_PACKAGES="pip gzip tar unzip openssl shadow-utils xz wget gnupg dirmngr"
 RUN dnf update -y &&\
     dnf install -y ${DNF_PACKAGES} --allowerasing
 
+RUN dnf update -y ca-certificates --releasever 2023.1.20230823
+
 RUN rm -rf /var/log/* &&\
     dnf clean all &&\
     rm -rf /var/cache/dnf

--- a/Grafana_Codebuild/goss.yaml
+++ b/Grafana_Codebuild/goss.yaml
@@ -44,10 +44,12 @@ file:
 package:
   jq:
     installed: true
-  cronie:
-    installed: true
-    versions:
-      - 1.4.11
+command:
+  'yum info cronie | grep Version':
+    exit-status: 0
+    timeout: 20000
+    stdout:
+    - "Version     : 1.4.11"
 user:
   grafana:
     exists: true


### PR DESCRIPTION
This PR fixes CVE-2023-37920 vulnerability.