### PR TITLE
Updated readme to show core api using the right image

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Docker image builds for the Bichard 7 project
 -   [Amazon Linux 2023 Base](./Amazon_Linux_2023_Base/Dockerfile) - Amazonlinux 2 with patches and some base sofware installed
     -   [Conductor](./Conductor/Dockerfile) - The Conductor image
     -   [NodeJS 2023](./NodeJS_2023/) - Node 16 on Amazon Linux 2023
-        -   [Nginx NodeJS 2023 Supervisord](./Nginx_NodeJS_2023_Supervisord/) - The above with Nginx and Supoervisord installed
+        -   [Nginx NodeJS 2023 Supervisord](./Nginx_NodeJS_2023_Supervisord/) - The above with Nginx and Supervisord installed
     -   [NodeJS 20 2023](./NodeJS_2023/) - Node 20 on Amazon Linux 2023
         -   [Nginx NodeJS 20 2023 Supervisord](./Nginx_NodeJS_20_2023_Supervisord/) - The above with Nginx and Supervisord installed
             -   Used by: [Bichard User Service](https://github.com/ministryofjustice/bichard7-next-user-service)
             -   Used by: [Bichard UI](https://github.com/ministryofjustice/bichard7-next-ui)
+        -   Used by: [Core API](https://github.com/ministryofjustice/bichard7-next-core/blob/main/packages/api/Dockerfile)
         -   Used by: [Core Conductor Worker](https://github.com/ministryofjustice/bichard7-next-core/blob/main/packages/conductor/Dockerfile)
         -   Used by: [Audit Log API](https://github.com/ministryofjustice/bichard7-next-audit-logging/blob/main/src/audit-log-api/Dockerfile) - for testing only
         -   Used by: [Event Handler](https://github.com/ministryofjustice/bichard7-next-audit-logging/blob/main/src/event-handler/Dockerfile) - for testing only


### PR DESCRIPTION
I have reordered the list of images as was a bit out of order. 

Do we still use `nginx-nodejs-2023-supervisord`? Is this superseded by the newer `nginx-nodejs-20-2023-supervisord`?
