### PR TITLE
Increase the max request body size in Conductor Nginx to 100 MB

### DIFF
--- a/Conductor/confd/templates/nginx.conf.tpl
+++ b/Conductor/confd/templates/nginx.conf.tpl
@@ -13,6 +13,7 @@ http {
     tcp_nodelay               on;
     keepalive_timeout         500;
     types_hash_max_size       2048;
+    client_max_body_size      100m;
     include                   /etc/nginx/mime.types;
     default_type              application/octet-stream;
     ssl_protocols             TLSv1.2; # Dropping SSLv3, ref: POODLE


### PR DESCRIPTION
Default client_max_body_size is 1MB. This PR increases the maximum body size to 100MB for Conductor NGINX.