### PR TITLE
Update amazon linux 2023 base image for terraform and chrome

### DIFF
--- a/Amazon_Linux_2023_Base/Dockerfile
+++ b/Amazon_Linux_2023_Base/Dockerfile
@@ -3,16 +3,27 @@ ARG BUILD_IMAGE="amazonlinux:2023"
 FROM ${BUILD_IMAGE}
 
 LABEL maintainer="CJSE"
-ARG DNF_PACKAGES="pip gzip tar unzip openssl shadow-utils xz wget gnupg dirmngr"
+ARG TERRAFORM_VERSION="1.8.4"
+ARG DNF_PACKAGES="pip gzip tar unzip openssl shadow-utils xz wget gnupg"
 
-RUN dnf update -y &&\
-    dnf install -y ${DNF_PACKAGES} --allowerasing
+RUN dnf update -y
+RUN dnf install -y ${DNF_PACKAGES}
+RUN dnf install dirmngr -y --allowerasing
+RUN dnf install -y "https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm"
 
 RUN dnf update -y ca-certificates --releasever 2023.1.20230823
 RUN dnf update -y zlib --releasever 2023.2.20231030 
 
+RUN pip3 install --ignore-installed pip
+RUN pip3 install awscli boto3 click botocore requests
+
+COPY ./scripts /tmp
+RUN bash /tmp/install_terraform.sh
+
 RUN rm -rf /var/log/* &&\
     dnf clean all &&\
-    rm -rf /var/cache/dnf
+    rm -rf /var/cache/dnf && \
+    rm -rf /tmp/*.zip && \
+    rm -rf /tmp/*.sh
 
 CMD ["tail", "-f", "/dev/null"]

--- a/Amazon_Linux_2023_Base/build.sh
+++ b/Amazon_Linux_2023_Base/build.sh
@@ -4,7 +4,15 @@ set -e
 
 IMAGE="amazon-linux2023-base"
 
-docker build -t "${IMAGE}" . 
+if [ -z "$PLATFORM" ]; then
+  PLATFORM=$(arch)
+fi
+
+if [ "$PLATFORM" = "arm64" ]; then
+  docker build --platform linux/x86_64 -t $IMAGE .
+else
+  docker build -t "${IMAGE}" . 
+fi
 
 if [ "$SKIP_GOSS" = "true" ]; then
   echo "Skipping dgoss tests"

--- a/Amazon_Linux_2023_Base/scripts/install_terraform.sh
+++ b/Amazon_Linux_2023_Base/scripts/install_terraform.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd /tmp
+wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+unzip -o terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+chmod +x terraform
+mv terraform /usr/bin/terraform

--- a/NodeJS_20_2023/Dockerfile
+++ b/NodeJS_20_2023/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="CJSE"
 ARG NODE_USER="node"
 ARG NODE_GUID=1000
 ARG ARCH="x64"
-ARG NODE_VERSION="16.18.1"
+ARG NODE_VERSION="20.18.0"
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 


### PR DESCRIPTION
This PR updates amazon linux base image to install chrome and terraform.
It also updated nodejs version to version 20.18.0 in nodejs 2023 image.