### PR TITLE
Fix CVE-2026-29145 in Conductor

### DIFF
--- a/Conductor/Dockerfile
+++ b/Conductor/Dockerfile
@@ -27,7 +27,7 @@ RUN git clone --depth=1 -b ${CONDUCTOR_VERSION} https://github.com/conductor-oss
 
 WORKDIR /conductor
 
-RUN sed -i 's/^subprojects {$/ext["tomcat.version"] = "10.1.41"\n\n&/' build.gradle
+RUN sed -i 's/^subprojects {$/ext["tomcat.version"] = "10.1.53"\n\n&/' build.gradle
 RUN sed -i "s/revRedisson = '3\.13\.3'/revRedisson = '3.22.0'/" dependencies.gradle
 
 #This will cache the downloaded gradle so repeated runs are faster

--- a/Conductor/Makefile
+++ b/Conductor/Makefile
@@ -27,7 +27,7 @@ else
 		-e AWS_DEFAULT_REGION=eu-west-2 \
 		-e LOCALSTACK_HOST=goss-localstack \
 		-e SQS_ENDPOINT_STRATEGY=path \
-		-d localstack/localstack
+		-d localstack/localstack:4.7.0
 	docker run --net goss-net --name goss-postgres -e POSTGRES_PASSWORD=password -d postgres
 	GOSS_WAIT_OPTS="-r 120s -s 3s" dgoss run \
 		--net goss-net \


### PR DESCRIPTION
There is a [CVE](https://nvd.nist.gov/vuln/detail/CVE-2026-29145) caused by Apache Tomcat. For now, Conductor itself has not patched this, I have opened up a [PR](https://github.com/conductor-oss/conductor/pull/1036) on the Conductor repo to address this. 

In the meantime whist we wait for a new version, we can just pin the version by overriding in the Dockerfile.