### PR TITLE
BICAWS7-4158 - Remove intercept errors on connectivity endpoint

### DIFF
--- a/Nginx_Auth_Proxy/files/templates/bichard.http.conf.tpl
+++ b/Nginx_Auth_Proxy/files/templates/bichard.http.conf.tpl
@@ -201,8 +201,7 @@ location /bichard/api/connectivity {
     proxy_cookie_flags ~ httponly samesite=strict;
     proxy_ssl_server_name on;
     proxy_ssl_verify_depth 2;
-    proxy_intercept_errors on;
-
+    proxy_intercept_errors off;
 
     # New Bichard User Service sets it's own CSP before it reaches nginx
     proxy_pass_header Content-Security-Policy;

--- a/Nginx_Auth_Proxy/files/templates/bichard.https.conf.tpl
+++ b/Nginx_Auth_Proxy/files/templates/bichard.https.conf.tpl
@@ -214,7 +214,7 @@ location /bichard/api/connectivity {
     proxy_cookie_flags ~ httponly secure samesite=strict;
     proxy_ssl_server_name on;
     proxy_ssl_verify_depth 2;
-    proxy_intercept_errors on;
+    proxy_intercept_errors off;
 
     # New Bichard User Service sets it's own CSP before it reaches nginx
     proxy_pass_header Content-Security-Policy;

--- a/Nginx_Auth_Proxy/test/nginx-auth-proxy.test.js
+++ b/Nginx_Auth_Proxy/test/nginx-auth-proxy.test.js
@@ -81,7 +81,7 @@ describe("Testing Nginx config", () => {
     { path: "/bichard-ui/css/style.css", route: "bichard", auth: false, errorsIntercepted: false },
     { path: "/bichard-backend/Health", route: "backend", dest: "/bichard-ui/Health", auth: false, errorsIntercepted: false },
     { path: "/bichard-backend/Connectivity", route: "backend", dest: "/bichard-ui/Connectivity", auth: false, errorsIntercepted: false },
-    { path: "/bichard/api/connectivity", route: "ui", auth: false, verbs: ["GET"] },
+    { path: "/bichard/api/connectivity", route: "ui", auth: false, verbs: ["GET"], errorsIntercepted: false },
   ];
 
   const defaultHeaders = {


### PR DESCRIPTION
Nginx was intercepting `401` errors from the UI and redirecting to the login screen. This is confusing because this ends up being a `200` with HTML when called programmatically. Not intercepting this now means we get the `401` back.