### PR TITLE
BICAWS7-3935 - Inline `BUILD_IMAGE` argument

### DIFF
--- a/Amazon_Linux_2023_Base/Dockerfile
+++ b/Amazon_Linux_2023_Base/Dockerfile
@@ -1,6 +1,4 @@
-ARG BUILD_IMAGE="amazonlinux:2023@sha256:ceeab7e010ed03ea155cfbbfd7140672eba5a49e1110b8b4ed35342312c3f21a"
-
-FROM "${BUILD_IMAGE}"
+FROM amazonlinux:2023@sha256:ceeab7e010ed03ea155cfbbfd7140672eba5a49e1110b8b4ed35342312c3f21a
 
 LABEL org.opencontainers.image.authors="CJSE"
 ARG DNF_PACKAGES="pip gzip tar unzip openssl shadow-utils xz wget gnupg"

--- a/Codebuild_Base/Dockerfile
+++ b/Codebuild_Base/Dockerfile
@@ -1,5 +1,4 @@
-ARG BUILD_IMAGE="public.ecr.aws/amazonlinux/amazonlinux:2@sha256:3ee7a08c5ea9013cc20063d97d42b003aed4b0e381562e5310f9a17d034100e9"
-FROM ${BUILD_IMAGE}
+FROM public.ecr.aws/amazonlinux/amazonlinux:2@sha256:3ee7a08c5ea9013cc20063d97d42b003aed4b0e381562e5310f9a17d034100e9
 
 ARG TERRAFORM_VERSION="1.8.4"
 ARG YUM_PACKAGES="python-pip python3-pip gzip tar unzip openssl shadow-utils xz wget gnupg curl jq git openvpn unzip"

--- a/Liquibase/Dockerfile
+++ b/Liquibase/Dockerfile
@@ -1,5 +1,4 @@
-ARG BUILD_IMAGE="liquibase/liquibase:5.0@sha256:32c10b8aa43534e704e533214e7b3f9d2898f3df01ac47b6e4a85358c53c836f"
-FROM ${BUILD_IMAGE}
+FROM liquibase/liquibase:5.0@sha256:32c10b8aa43534e704e533214e7b3f9d2898f3df01ac47b6e4a85358c53c836f
 
 LABEL org.opencontainers.image.authors="CJSE"
 


### PR DESCRIPTION
Dependabot daily checks aren't identifying updates to the images (amazonlinux:2 checked). It appears it does not support a `FROM` argument built up from args.