### PR TITLE
Upgrade Nginx to 1.31.0

### DIFF
--- a/Amazon_Linux_2023_Base/Dockerfile
+++ b/Amazon_Linux_2023_Base/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2023@sha256:ceeab7e010ed03ea155cfbbfd7140672eba5a49e1110b8b4ed35342312c3f21a
+FROM amazonlinux:2023@sha256:c1872fb69ff9ed9581c999509dd0dcb4288235087f1df4999b866affdac0278d
 
 LABEL org.opencontainers.image.authors="CJSE"
 ARG DNF_PACKAGES="pip gzip tar unzip openssl shadow-utils xz wget gnupg"

--- a/Codebuild_Base/Dockerfile
+++ b/Codebuild_Base/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2@sha256:3ee7a08c5ea9013cc20063d97d42b003aed4b0e381562e5310f9a17d034100e9
+FROM public.ecr.aws/amazonlinux/amazonlinux:2@sha256:18de48aa36400d9665d9aaca271c40dcf0923e0f0bfab21d7afaf41c0ba62245
 
 ARG TERRAFORM_VERSION="1.8.4"
 ARG YUM_PACKAGES="python-pip python3-pip gzip tar unzip openssl shadow-utils xz wget gnupg curl jq git openvpn unzip"

--- a/Nginx_Auth_Proxy/Dockerfile
+++ b/Nginx_Auth_Proxy/Dockerfile
@@ -39,7 +39,7 @@ RUN chmod 755 /bin/process_templates.sh && \
     /certs \
     /var/log/supervisor \
     /var/log/nginx \
-    /var/lib/nginx \
+    /var/cache/nginx \
     /etc/nginx
 
 EXPOSE 8080

--- a/Nginx_Auth_Proxy/files/nginx.repo
+++ b/Nginx_Auth_Proxy/files/nginx.repo
@@ -1,15 +1,17 @@
 [nginx-stable]
 name=nginx stable repo
-baseurl=http://nginx.org/packages/amzn2/$releasever/$basearch/
+baseurl=https://nginx.org/packages/amzn/2023/$basearch/
 gpgcheck=1
 enabled=1
 gpgkey=https://nginx.org/keys/nginx_signing.key
 module_hotfixes=true
+priority=9
 
 [nginx-mainline]
 name=nginx mainline repo
-baseurl=http://nginx.org/packages/mainline/amzn2/$releasever/$basearch/
+baseurl=https://nginx.org/packages/mainline/amzn/2023/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=https://nginx.org/keys/nginx_signing.key
 module_hotfixes=true
+priority=9

--- a/Nginx_Auth_Proxy/goss.yaml
+++ b/Nginx_Auth_Proxy/goss.yaml
@@ -88,7 +88,7 @@ user:
     exists: true
     groups:
       - nginx
-    home: /var/lib/nginx
+    home: /var/cache/nginx
     shell: /sbin/nologin
   nobody:
     exists: true


### PR DESCRIPTION
- Pin to latest amazonlinux 2 and amazonlinux 2023 images to 20260511.1
- Fix nginx package manager config to reference amazonlinux 2023 instead of amazonlinux 2.
- Fix appuser path to use correct amazonlinux 2023 path convention.