### PR TITLE
BICAWS7-3935 - Authenticate dependabot to DockerHub

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,18 @@
 version: 2
+registries:
+  dockerhub:
+    type: docker-registry
+    url: https://registry.hub.docker.com
+    username: ${{secrets.DOCKERHUB_USERNAME}}
+    password: ${{secrets.DOCKERHUB_TOKEN}}
 updates:
   - package-ecosystem: "docker"
     directories:
       - "/Amazon_Linux_2023_Base/"
       - "/Liquibase/"
       - "/Codebuild_Base/"
+    registries:
+      - dockerhub
     schedule:
       interval: "daily"
     cooldown:


### PR DESCRIPTION
Use read-only credentials to prevent being hit by public rate limit