### PR TITLE
BICAWS7-3935 - Change Codebuild_Base to use `amazonlinux:2` image from DockerHub

### DIFF
--- a/Codebuild_Base/Dockerfile
+++ b/Codebuild_Base/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2@sha256:18de48aa36400d9665d9aaca271c40dcf0923e0f0bfab21d7afaf41c0ba62245
+FROM amazonlinux:2@sha256:74e5c80ad36e6ef0f6fd4a55bb3cc969c05dec6b9dc27fdfa68c8e77264901f9
 
 ARG TERRAFORM_VERSION="1.8.4"
 ARG YUM_PACKAGES="python-pip python3-pip gzip tar unzip openssl shadow-utils xz wget gnupg curl jq git openvpn unzip"


### PR DESCRIPTION
`amazonlinux:2023` is currently pulled from DockerHub, this makes them consistent. DockerHub is easier for dependabot to auth against than ECR.