### PR TITLE
BICAWS7-3935 - Configure dependabot to only consider digest (sha256) updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,11 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 3
+    ignore:
+      - dependency-name: "amazonlinux"
+        # only consider digest updates for pinned images
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+


### PR DESCRIPTION
Configure dependabot to only consider digest (sha256) updates for pinned amazonlinux images. These are set to the product version and reduce the work required by dependabot to determine an update candidate. 

Dependabot crashes when attempting to find an update candidate, searching all 2023 tags as far back as 2023.6.20250114.0 - this change should fix that.