### PR TITLE
BICAWS7-4269 - Update Nginx on nginx_node docker image

### DIFF
--- a/Nginx_NodeJS_20_2023_Supervisord/Dockerfile
+++ b/Nginx_NodeJS_20_2023_Supervisord/Dockerfile
@@ -34,7 +34,7 @@ RUN chown -R node:node \
     /certs \
     /var/log/supervisor \
     /var/log/nginx \
-    /var/lib/nginx \
+    /var/cache/nginx \
     /etc/nginx
 
 EXPOSE 8080

--- a/Nginx_NodeJS_20_2023_Supervisord/Dockerfile
+++ b/Nginx_NodeJS_20_2023_Supervisord/Dockerfile
@@ -6,6 +6,7 @@ LABEL org.opencontainers.image.authors="CJSE"
 WORKDIR /
 
 COPY files/openssl.cnf /tmp/openssl.cnf
+COPY files/nginx.repo /etc/yum.repos.d/nginx.repo
 
 USER root
 

--- a/Nginx_NodeJS_20_2023_Supervisord/Dockerfile
+++ b/Nginx_NodeJS_20_2023_Supervisord/Dockerfile
@@ -37,13 +37,14 @@ RUN chown -R node:node \
     /var/cache/nginx \
     /etc/nginx
 
+RUN rm /etc/nginx/conf.d/default.conf
+COPY conf/supervisord.conf /etc/supervisord.conf
+COPY conf/nginx.conf /etc/nginx/nginx.conf
+
 EXPOSE 8080
 EXPOSE 8443
 
 WORKDIR /etc/nginx
-
-COPY conf/supervisord.conf /etc/supervisord.conf
-COPY conf/nginx.conf /etc/nginx/nginx.conf
 
 USER node
 

--- a/Nginx_NodeJS_20_2023_Supervisord/files/nginx.repo
+++ b/Nginx_NodeJS_20_2023_Supervisord/files/nginx.repo
@@ -1,0 +1,17 @@
+[nginx-stable]
+name=nginx stable repo
+baseurl=https://nginx.org/packages/amzn/2023/$basearch/
+gpgcheck=1
+enabled=1
+gpgkey=https://nginx.org/keys/nginx_signing.key
+module_hotfixes=true
+priority=9
+
+[nginx-mainline]
+name=nginx mainline repo
+baseurl=https://nginx.org/packages/mainline/amzn/2023/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=https://nginx.org/keys/nginx_signing.key
+module_hotfixes=true
+priority=9

--- a/Nginx_NodeJS_20_2023_Supervisord/goss.yaml
+++ b/Nginx_NodeJS_20_2023_Supervisord/goss.yaml
@@ -28,6 +28,8 @@ file:
     group: root
     filetype: file
     contains: []
+  /etc/nginx/conf.d/default.conf:
+    exists: false
   /var/log/nginx:
     exists: true
     filetype: directory

--- a/Nginx_NodeJS_20_2023_Supervisord/goss.yaml
+++ b/Nginx_NodeJS_20_2023_Supervisord/goss.yaml
@@ -33,7 +33,7 @@ file:
     filetype: directory
     owner: node
     group: node
-  /var/lib/nginx:
+  /var/cache/nginx:
     exists: true
     filetype: directory
     owner: node
@@ -89,7 +89,7 @@ user:
     exists: true
     groups:
       - nginx
-    home: /var/lib/nginx
+    home: /var/cache/nginx
     shell: /sbin/nologin
   nobody:
     exists: true

--- a/S3_Web_Proxy/goss.yaml
+++ b/S3_Web_Proxy/goss.yaml
@@ -28,12 +28,14 @@ file:
     owner: root
     group: root
     filetype: file
+  /etc/nginx/conf.d/default.conf:
+    exists: false
   /var/log/nginx:
     exists: true
     filetype: directory
     owner: node
     group: node
-  /var/lib/nginx:
+  /var/cache/nginx:
     exists: true
     filetype: directory
     owner: node
@@ -81,7 +83,7 @@ user:
     exists: true
     groups:
       - nginx
-    home: /var/lib/nginx
+    home: /var/cache/nginx
     shell: /sbin/nologin
   nobody:
     exists: true


### PR DESCRIPTION
* Use correct repo for AWS Linux 2023
* Change directory for nginx binary and remove default conf that now gets added