### PR TITLE
BICAWS7-4219 - Trigger core artefact job when building Node.js 24 images

### DIFF
--- a/Nginx_NodeJS_20_2023_Supervisord/scripts/build_docker.sh
+++ b/Nginx_NodeJS_20_2023_Supervisord/scripts/build_docker.sh
@@ -9,6 +9,3 @@ export readonly SOURCE_REPOSITORY_NAME="nodejs-20-2023"
 
 aws codebuild start-build --project-name "build-s3-web-proxy" \
   --environment-variables-override name=DOCKER_IMAGE_HASH,value="${DOCKER_IMAGE_PREFIX}@${SHA_HASH}",type=PLAINTEXT
-
-aws codebuild start-build --project-name "build-core-repo-artifacts" \
-  --environment-variables-override name=DOCKER_IMAGE_HASH,value="${DOCKER_IMAGE_PREFIX}@${SHA_HASH}",type=PLAINTEXT

--- a/Nginx_NodeJS_24_2023_Supervisord/scripts/build_docker.sh
+++ b/Nginx_NodeJS_24_2023_Supervisord/scripts/build_docker.sh
@@ -11,6 +11,5 @@ export readonly SOURCE_REPOSITORY_NAME="nodejs-24-2023"
 #aws codebuild start-build --project-name "build-s3-web-proxy" \
 #  --environment-variables-override name=DOCKER_IMAGE_HASH,value="${DOCKER_IMAGE_PREFIX}@${SHA_HASH}",type=PLAINTEXT
 
-# Re-instate when Core images are using the new base image
-#aws codebuild start-build --project-name "build-core-repo-artifacts" \
-#  --environment-variables-override name=DOCKER_IMAGE_HASH,value="${DOCKER_IMAGE_PREFIX}@${SHA_HASH}",type=PLAINTEXT
+aws codebuild start-build --project-name "build-core-repo-artifacts" \
+  --environment-variables-override name=DOCKER_IMAGE_HASH,value="${DOCKER_IMAGE_PREFIX}@${SHA_HASH}",type=PLAINTEXT


### PR DESCRIPTION
Also remove the trigger on Node.js 20 image builds