### PR TITLE
Bicaws7 3970 update only commands

### DIFF
--- a/Amazon_Linux_2023_Base/Dockerfile
+++ b/Amazon_Linux_2023_Base/Dockerfile
@@ -5,18 +5,14 @@ ARG DNF_PACKAGES="pip gzip tar unzip openssl shadow-utils xz wget gnupg dirmngr 
 
 # Install required packages
 RUN dnf update -y && \
-    dnf install -y --setopt=install_weak_deps=False --allowerasing ${DNF_PACKAGES}
-
-# Install updates
-RUN dnf update -y ca-certificates --releasever 2023.1.20230823 && \
-    dnf update -y zlib --releasever 2023.2.20231030
+    dnf install -y --setopt=install_weak_deps=False --allowerasing ${DNF_PACKAGES} && \
+    dnf update -y ca-certificates --releasever 2023.1.20230823 && \
+    dnf update -y zlib --releasever 2023.2.20231030 && \
+    rm -rf /var/log/* && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 RUN useradd -r -m -s /bin/bash appuser
-
-# Cleanup
-RUN rm -rf /var/log/* &&\
-    dnf clean all &&\
-    rm -rf /var/cache/dnf
 
 USER appuser
 

--- a/Codebuild_Base/Dockerfile
+++ b/Codebuild_Base/Dockerfile
@@ -11,8 +11,8 @@ ARG NODE_VERSION="16.18.1"
 
 COPY ./scripts /tmp
 
-RUN amazon-linux-extras install -y epel &&\
-    yum install -y --setopt=install_weak_deps=False deltarpm &&\
+RUN amazon-linux-extras install -y epel && \
+    yum install -y --setopt=install_weak_deps=False deltarpm && \
     bash /tmp/install_packages.sh && \
     bash /tmp/install_terraform.sh && \
     bash /tmp/install_nodejs.sh && \

--- a/Conductor/Dockerfile
+++ b/Conductor/Dockerfile
@@ -4,12 +4,14 @@ FROM node:20-alpine AS ui-builder
 
 ARG CONDUCTOR_VERSION
 
-RUN apk add git
-RUN git clone --depth=1 -b ${CONDUCTOR_VERSION} https://github.com/conductor-oss/conductor.git /conductor
+RUN apk add git && \
+    git clone --depth=1 -b ${CONDUCTOR_VERSION} https://github.com/conductor-oss/conductor.git /conductor
 
 WORKDIR /conductor/ui
-RUN npm install --legacy-peer-deps
-RUN npm run build
+
+RUN npm install --legacy-peer-deps && \
+    npm cache clean --force && \
+    npm run build
 
 # ===========================================================================================================
 # 0. Builder stage
@@ -19,20 +21,20 @@ FROM eclipse-temurin:17-jdk-jammy AS builder
 ARG CONDUCTOR_VERSION
 
 RUN apt-get update && apt-get install -y --no-install-recommends git && \
+    git clone --depth=1 -b ${CONDUCTOR_VERSION} https://github.com/conductor-oss/conductor.git /conductor && \
     rm -rf /var/lib/apt/lists/*
-
-RUN git clone --depth=1 -b ${CONDUCTOR_VERSION} https://github.com/conductor-oss/conductor.git /conductor
 
 # Build the server
 
 WORKDIR /conductor
 
-RUN sed -i 's/^subprojects {$/ext["tomcat.version"] = "10.1.55"\n\n&/' build.gradle
-RUN sed -i "s/revRedisson = '3\.13\.3'/revRedisson = '3.22.0'/" dependencies.gradle
+RUN sed -i 's/^subprojects {$/ext["tomcat.version"] = "10.1.55"\n\n&/' build.gradle && \
+    sed -i "s/revRedisson = '3\.13\.3'/revRedisson = '3.22.0'/" dependencies.gradle
 
 #This will cache the downloaded gradle so repeated runs are faster
-RUN ./gradlew --version
-RUN ./gradlew build -x test
+RUN ./gradlew --version && \
+    ./gradlew build -x test && \
+    rm -rf /root/.gradle
 
 # ===========================================================================================================
 # 1. Bin stage
@@ -50,7 +52,7 @@ USER root
 COPY files/openssl.cnf /tmp/openssl.cnf
 
 RUN mkdir -p /certs /var/log/supervisor && \
-    yum install -y --setopt=install_weak_deps=False nginx httpd-tools gettext && \
+    yum install -y --setopt=install_weak_deps=False nginx httpd-tools gettext java-17-amazon-corretto && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     pip install --no-cache-dir supervisor && \
@@ -61,11 +63,6 @@ RUN mkdir -p /certs /var/log/supervisor && \
 
 # Make app folders
 RUN mkdir -p /app/config /app/logs /app/libs
-
-# Install Java
-RUN dnf update && \
-    dnf install -y --setopt=install_weak_deps=False java-17-amazon-corretto && \
-    dnf clean all
 
 # Copy the compiled output to new image
 COPY --from=builder --chown=appuser:appuser /conductor/server/build/libs/*boot*.jar /app/libs/conductor-server.jar

--- a/Nginx_Auth_Proxy/Dockerfile
+++ b/Nginx_Auth_Proxy/Dockerfile
@@ -13,8 +13,8 @@ COPY files/nginx.repo /etc/yum.repos.d/nginx.repo
 
 RUN mkdir -p /certs /var/log/supervisor && \
     yum update -y && \
-    yum-config-manager --enable nginx-mainline && \
     yum install -y --setopt=install_weak_deps=False yum-utils nginx httpd-tools gettext && \
+    yum-config-manager --enable nginx-mainline && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     openssl req -x509 -nodes -days 730 -newkey rsa:4096 -out /certs/server.crt \

--- a/Nginx_Auth_Proxy/Dockerfile
+++ b/Nginx_Auth_Proxy/Dockerfile
@@ -9,23 +9,18 @@ COPY files/openssl.cnf /tmp/openssl.cnf
 
 USER root
 
-RUN mkdir -p /certs && \
-    mkdir -p /var/log/supervisor && \
-    yum update -y && \
-    yum install -y --setopt=install_weak_deps=False yum-utils
-
 COPY files/nginx.repo /etc/yum.repos.d/nginx.repo
 
-RUN yum-config-manager --enable nginx-mainline && \
-    yum install -y --setopt=install_weak_deps=False nginx httpd-tools && \
-    pip install --no-cache-dir supervisor && \
+RUN mkdir -p /certs /var/log/supervisor && \
+    yum update -y && \
+    yum-config-manager --enable nginx-mainline && \
+    yum install -y --setopt=install_weak_deps=False yum-utils nginx httpd-tools gettext && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     openssl req -x509 -nodes -days 730 -newkey rsa:4096 -out /certs/server.crt \
     -keyout /certs/server.key -config /tmp/openssl.cnf -extensions 'v3_req' && \
-    rm -rf /tmp/openssl.cnf
-
-RUN yum install -y gettext
+    rm -rf /tmp/openssl.cnf && \
+    pip install --no-cache-dir supervisor
 
 RUN rm /etc/nginx/conf.d/default.conf
 COPY files/templates /etc/templates/
@@ -40,8 +35,7 @@ RUN chmod 755 /bin/process_templates.sh && \
     /certs \
     /var/log/supervisor \
     /var/log/nginx \
-    /var/cache/nginx \
-    /etc/nginx
+    /var/cache/nginx
 
 EXPOSE 8080
 EXPOSE 8443

--- a/Nginx_NodeJS_24_2023_Supervisord/Dockerfile
+++ b/Nginx_NodeJS_24_2023_Supervisord/Dockerfile
@@ -26,9 +26,8 @@ RUN mkdir -p /certs && \
       -keyout /certs/server.key \
       -config /tmp/openssl.cnf \
       -extensions 'v3_req' && \
-    rm -rf /tmp/openssl.cnf
-
-RUN pip install --no-cache-dir supervisor
+    rm -rf /tmp/openssl.cnf && \
+    pip install --no-cache-dir supervisor
 
 RUN chown -R node:node \
     /certs \

--- a/Postfix/Dockerfile
+++ b/Postfix/Dockerfile
@@ -7,24 +7,28 @@ ARG CONFD_CHECKSUM="255d2559f3824dd64df059bdc533fd6b697c070db603c76aaf8d1d5e6b0c
 # We need to run as root for Postfix to work
 USER root
 
-RUN yum install -y --setopt=install_weak_deps=False tzdata && \
-    ln -sf /usr/share/zoneinfo/Europe/London /etc/localtime && \
-    echo "Europe/London" > /etc/timezone
-
 ENV TZ=Europe/London
 
-RUN yum install -y --setopt=install_weak_deps=False postfix cyrus-sasl rsyslog s-nail && \
+RUN dnf update -y && \
+    dnf install -y --setopt=install_weak_deps=False --allowerasing \
+        tzdata \
+        postfix \
+        cyrus-sasl \
+        rsyslog \
+        s-nail \
+        wget && \
+    ln -sf /usr/share/zoneinfo/Europe/London /etc/localtime && \
+    echo "Europe/London" > /etc/timezone && \
     pip install --no-cache-dir supervisor && \
-    mkdir -p /var/log/supervisor && \
+    mkdir -p /var/log/supervisor /etc/confd/ && \
     sed -i -e 's/inet_interfaces = localhost/inet_interfaces = all/g' /etc/postfix/main.cf && \
-    yum clean all && \
-    rm -rf /var/cache/yum && \
     wget -O /bin/confd https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 -nv && \
     echo "${CONFD_CHECKSUM}  /bin/confd" | sha256sum -c && \
     chmod +x /bin/confd && \
-    mkdir -p /etc/confd/ && \
     touch /var/log/maillog && \
-    chown postfix:postfix /var/log/maillog
+    chown postfix:postfix /var/log/maillog && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf /var/log/*
 
 COPY ./files/conf/master.cf /etc/postfix/master.cf
 COPY ./confd /etc/confd


### PR DESCRIPTION
This PR addresses the security/optimisation [finding](https://dsdmoj.atlassian.net/jira/software/c/projects/BICAWS7/boards/1368?selectedIssue=BICAWS7-3970) from the IT Health Check: 
> *"Updating package indices without installing packages may result in stale metadata or inconsistencies across layers."*


Previously, some of our Dockerfiles separated the package index updates (e.g. `dnf update -y` or `yum update -y`) from the actual package installations into distinct `RUN` commands, or ran them sequentially across multiple layers. 

Because of how Docker caches layers, an isolated update layer can become stale. If a downstream installation line is modified later, Docker might reuse the cached, outdated package index, leading to broken builds, mismatched package versions, or missing security patches.