### PR TITLE
BICAWS7-4274 - Remove default nginx conf - it configures nginx to listen on port 80 …

### DIFF
--- a/Conductor/Dockerfile
+++ b/Conductor/Dockerfile
@@ -70,6 +70,7 @@ RUN mkdir -p /app/config /app/logs /app/libs
 COPY --from=builder --chown=appuser:appuser /conductor/server/build/libs/*boot*.jar /app/libs/conductor-server.jar
 
 # Copy the config files
+RUN rm /etc/nginx/conf.d/default.conf
 COPY files/nginx.conf /etc/nginx/nginx.conf
 COPY files/config.properties /app/config/config.properties
 COPY files/templates /etc/templates/

--- a/Conductor/goss.yaml
+++ b/Conductor/goss.yaml
@@ -94,6 +94,8 @@ port:
     listening: true
   tcp:8080:
     listening: true
+  tcp:80:
+    listening: false
 process:
   nginx:
     running: true


### PR DESCRIPTION
…which isn't required