### PR TITLE
BICAWS7-3980 - Fix issue caused by not handling protocol of origin header

### DIFF
--- a/S3_Web_Proxy/s3-server/bin/server.js
+++ b/S3_Web_Proxy/s3-server/bin/server.js
@@ -96,8 +96,9 @@ app.use((req, res, next) => {
     } else {
         const allowedOrigins = process.env.ALLOWED_ORIGINS.split(",")
         const origin = req.headers.origin;
+        const originHostname = origin ? origin.replace(/^https?:\/\//, '') : '';
 
-        if (allowedOrigins.includes(origin)) {
+        if (allowedOrigins.includes(originHostname)) {
             res.setHeader('Access-Control-Allow-Origin', origin);
         }
     }


### PR DESCRIPTION
`req.headers.origin` includes the protocol whereas our env variables are just the hostname. As we have some small usage of `http` currently it was easier to make the change here than to append the protocols in the env variable