### PR TITLE
Fix CVE-2026-59873

### DIFF
--- a/Codebuild_2023_Base/Dockerfile
+++ b/Codebuild_2023_Base/Dockerfile
@@ -3,6 +3,8 @@ FROM ${BUILD_IMAGE}
 
 ARG TERRAFORM_VERSION="1.12.1"
 ARG NODE_VERSION="24.14.0"
+# We're pinning NPM to fix CVE-2026-59873 - The version of NPM installed with Node 24.14.0 does not have a new enough version of NPM
+ARG NPM_VERSION="11.18.0"
 ARG DNF_PACKAGES="python python-pip python3-pip jq git ruby ruby-devel"
 ARG TEST_PACKAGES="which"
 ARG PIP_PACKAGES="awscli boto3 click botocore requests"

--- a/Codebuild_2023_Base/scripts/install_nodejs.sh
+++ b/Codebuild_2023_Base/scripts/install_nodejs.sh
@@ -26,5 +26,6 @@ grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c -
 tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner
 rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 ln -s /usr/local/bin/node /usr/local/bin/nodejs
+npm install -g npm@$NPM_VERSION
 node --version
 npm --version

--- a/NodeJS_24_2023/Dockerfile
+++ b/NodeJS_24_2023/Dockerfile
@@ -7,6 +7,8 @@ ARG NODE_USER="node"
 ARG NODE_GUID=1000
 ARG ARCH="x64"
 ARG NODE_VERSION="24.14.0"
+# We're pinning NPM to fix CVE-2026-59873 - The version of NPM installed with Node 24.14.0 does not have a new enough version of NPM
+ARG NPM_VERSION="11.18.0"
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 
@@ -36,6 +38,7 @@ RUN groupadd --gid ${NODE_GUID} ${NODE_USER} && \
     tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner && \
     rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt && \
     ln -s /usr/local/bin/node /usr/local/bin/nodejs && \
+    npm install -g npm@$NPM_VERSION && \
     node --version && \
     npm --version && \
     mkdir -p /opt && \


### PR DESCRIPTION
This fixes the following [CVE](https://avd.aquasec.com/nvd/2026/cve-2026-59873/) caused by `node-tar`. `node-tar` is a dependency of `npm` so in order to fix we needed to have a newer version installed. `npm` version `11.18.0` contains the fix but isn't included in any version of Node.js just yet so to fix we are manually installing newer version of `npm` for now.

When we next update Node.js, it will hopefully include a newer version so we can remove this.